### PR TITLE
dev: skip use of npm i when testing locally

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,7 +1,15 @@
+# cache dependencies
+FROM node:20-slim AS node_cache
+WORKDIR /cache/
+COPY package*.json .
+RUN npm install --prefer-offline --no-audit --progress=true --loglevel verbose --omit=dev
+
 # build and start
 FROM node:20-slim as build
 ARG ENV=development
 ENV NEXT_PUBLIC_ENV=$ENV
 WORKDIR /web
+COPY --from=node_cache /cache/ .
+COPY . .
 RUN printf "NEXT_PUBLIC_ENV=${ENV}" >> .env
 ENTRYPOINT [ "npm", "run", "dev" ]


### PR DESCRIPTION
Right now the first thing we have to do after cloning the repo is do `npm i` in the web folder. This seems redundant and if any debugging needs to be done just do it after entering the docker using command `docker compose -it <image> bash`.

If this was done on purpose, then even the python backend should have had no `pip install` in the dev dockerfile but it does. This commit removes the need for it.