### PR TITLE
database: change datetime into start and end time strings

### DIFF
--- a/src/app/actions/events/create/route.jsx
+++ b/src/app/actions/events/create/route.jsx
@@ -6,7 +6,6 @@ import { CREATE_EVENT } from "gql/mutations/events";
 export async function POST(request) {
   const response = { ok: false, data: null, error: null };
   const { details } = await request.json();
-
   const {
     data: { createEvent },
     error,

--- a/src/app/actions/events/venues/route.jsx
+++ b/src/app/actions/events/venues/route.jsx
@@ -11,7 +11,8 @@ export async function POST(request) {
     data: { availableRooms },
     error,
   } = await getClient().query(GET_AVAILABLE_LOCATIONS, {
-    timeslot: [startDate, endDate],
+    startTime: startDate,
+    endTime: endDate,
     eventid: eventid,
   });
   if (error) {

--- a/src/app/events/page.jsx
+++ b/src/app/events/page.jsx
@@ -2,6 +2,7 @@ import { Box, Divider, Typography } from "@mui/material";
 import EventsFilter from "components/events/EventsFilter";
 
 import EventsGrid from "components/events/EventsGrid";
+import {getDateObj} from "utils/formatTime";
 
 export const metadata = {
   title: "Events",
@@ -44,7 +45,7 @@ export default async function Events({ searchParams }) {
               if (!targetState) selectedState = true;
               else {
                 const isUpcoming =
-                  new Date(event?.datetimeperiod[1]) > new Date();
+                  new getDateObj(event?.endTime) > new Date();
                 selectedState = isUpcoming;
               }
 
@@ -84,7 +85,7 @@ export default async function Events({ searchParams }) {
               if (!targetState) selectedState = true;
               else {
                 const isUpcoming =
-                  new Date(event?.datetimeperiod[1]) > new Date();
+                  new getDateObj(event?.endTime) > new Date();
                 selectedState = !isUpcoming;
               }
 

--- a/src/app/manage/events/[id]/copy/page.jsx
+++ b/src/app/manage/events/[id]/copy/page.jsx
@@ -11,24 +11,11 @@ export const metadata = {
   title: "New Event",
 };
 
-function transformDateTime(datetimeperiod) {
-  let start = new Date(datetimeperiod[0]);
-  let end = new Date(datetimeperiod[1]);
-
-  let duration = end - start;
-
-  let newStart = new Date(datetimeperiod[0]);
-  newStart.setDate(new Date().getDate() + 7);
-  let newEnd = new Date(newStart.getTime() + duration);
-
-  return [newStart, newEnd];
-}
-
 function transformEvent(event) {
   return {
     ...event,
-    // parse datetime strings to date objects
-    datetimeperiod: transformDateTime(event?.datetimeperiod),
+    startTime: event?.startTime,
+    endTime: event?.endTime,
     budget: [],
     location: [],
     // parse population as int

--- a/src/app/manage/events/[id]/copy/page.jsx
+++ b/src/app/manage/events/[id]/copy/page.jsx
@@ -11,11 +11,25 @@ export const metadata = {
   title: "New Event",
 };
 
+function transformDateTime(datetimeperiod) {
+  let start = new Date(datetimeperiod[0]);
+  let end = new Date(datetimeperiod[1]);
+
+  let duration = end - start;
+
+  let newStart = new Date(datetimeperiod[0]);
+  newStart.setDate(new Date().getDate() + 7);
+  let newEnd = new Date(newStart.getTime() + duration);
+
+  return [newStart, newEnd];
+}
+
 function transformEvent(event) {
+  let newDatetime = transformDateTime([event?.startTime, event?.endTime]);
   return {
     ...event,
-    startTime: event?.startTime,
-    endTime: event?.endTime,
+    startTime: newDatetime[0],
+    endTime: newDatetime[1],
     budget: [],
     location: [],
     // parse population as int

--- a/src/app/manage/events/[id]/edit/page.jsx
+++ b/src/app/manage/events/[id]/edit/page.jsx
@@ -14,11 +14,8 @@ export const metadata = {
 function transformEvent(event) {
   return {
     ...event,
-    // parse datetime strings to date objects
-    datetimeperiod: [
-      new Date(event?.datetimeperiod[0]),
-      new Date(event?.datetimeperiod[1]),
-    ],
+    startTime: event?.startTime,
+    endTime: event?.endTime,
     // add mandatory ID field for DataGrid
     budget:
       event?.budget?.map((budget, key) => ({

--- a/src/app/manage/events/[id]/edit/page.jsx
+++ b/src/app/manage/events/[id]/edit/page.jsx
@@ -7,6 +7,8 @@ import { Container, Typography } from "@mui/material";
 
 import EventForm from "components/events/EventForm";
 
+import {getDateObj} from "utils/formatTime";
+
 export const metadata = {
   title: "Edit Event",
 };
@@ -14,8 +16,8 @@ export const metadata = {
 function transformEvent(event) {
   return {
     ...event,
-    startTime: event?.startTime,
-    endTime: event?.endTime,
+    startTime: getDateObj(event?.startTime),
+    endTime: getDateObj(event?.endTime),
     // add mandatory ID field for DataGrid
     budget:
       event?.budget?.map((budget, key) => ({

--- a/src/app/manage/events/[id]/page.jsx
+++ b/src/app/manage/events/[id]/page.jsx
@@ -32,6 +32,8 @@ import {
 import { locationLabel } from "utils/formatEvent";
 import MemberListItem from "components/members/MemberListItem";
 
+import {getDateObj} from "utils/formatTime"
+
 export async function generateMetadata({ params }, parent) {
   const { id } = params;
 
@@ -165,7 +167,7 @@ export default async function ManageEvent({ params }) {
 
 // set conditional actions based on event datetime, current status and user role
 function getActions(event, user) {
-  const upcoming = new Date(event?.datetimeperiod[0]) >= new Date();
+  const upcoming = getDateObj(event?.startTime) >= new Date();
 
   /*
    * Deleted Event

--- a/src/app/manage/events/new/page.jsx
+++ b/src/app/manage/events/new/page.jsx
@@ -11,7 +11,8 @@ export default function NewEvent() {
   const defaultValues = {
     clubid: "",
     name: "",
-    datetimeperiod: [null, null],
+    startTime: "",
+    endTime: "",
     description: "",
     audience: [],
     poster: "",

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -11,8 +11,8 @@ function eventDataTransform(event, role, uid) {
     return {
       id: event._id,
       title: event.name,
-      start: new Date(event.datetimeperiod[0]),
-      end: new Date(event.datetimeperiod[1]),
+      start: event.startTime,
+      end: event.endTime,
       backgroundColor: stc(event.clubid),
       url: `/events/${event._id}`,
       display: "block",
@@ -22,8 +22,8 @@ function eventDataTransform(event, role, uid) {
       return {
         id: event._id,
         title: event.name,
-        start: new Date(event.datetimeperiod[0]),
-        end: new Date(event.datetimeperiod[1]),
+        start: event.startTime,
+        end: event.endTime,
         backgroundColor: stc(event.clubid),
         url: `/manage/events/${event._id}`,
         display: "block",
@@ -32,8 +32,8 @@ function eventDataTransform(event, role, uid) {
       return {
         id: event._id,
         title: event.name,
-        start: new Date(event.datetimeperiod[0]),
-        end: new Date(event.datetimeperiod[1]),
+        start: event.startTime,
+        end: event.endTime,
         backgroundColor: stc(event.clubid),
         display: "block",
       };

--- a/src/components/DateTime.jsx
+++ b/src/components/DateTime.jsx
@@ -1,7 +1,0 @@
-"use client";
-
-import { ISOtoHuman } from "utils/formatTime";
-
-export default function DateTime({ dt, showWeekDay = false }) {
-  return ISOtoHuman(dt, showWeekDay);
-}

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -5,13 +5,13 @@ import { Box, Card, CardActionArea, Typography, Stack } from "@mui/material";
 
 import EventPoster from "components/events/EventPoster";
 import EventFallbackPoster from "components/events/EventFallbackPoster";
-
-const DateTime = dynamic(() => import("components/DateTime"), { ssr: false });
+import {appendWeekday} from "utils/formatTime"
 
 export default function EventCard({
   _id,
   name,
-  datetimeperiod,
+  startTime,
+  endTime,
   poster,
   clubid,
 }) {
@@ -31,7 +31,7 @@ export default function EventCard({
             {name}
           </Typography>
           <Typography variant="caption" noWrap>
-            <DateTime dt={datetimeperiod?.[0]} showWeekDay={true} />
+	    {appendWeekday(startTime)}
           </Typography>
         </Stack>
       </CardActionArea>

--- a/src/components/events/EventDetails.jsx
+++ b/src/components/events/EventDetails.jsx
@@ -11,8 +11,6 @@ import EventFallbackPoster from "components/events/EventFallbackPoster";
 
 import Icon from "components/Icon";
 
-const DateTime = dynamic(() => import("components/DateTime"), { ssr: false });
-
 export default function EventDetails({ event, showCode = false }) {
   return (
     <Grid container spacing={2}>
@@ -43,11 +41,11 @@ export default function EventDetails({ event, showCode = false }) {
           <Box display="flex" alignItems="center">
             <Icon variant="calendar-today" sx={{ mr: 2, width: 16 }} />
             <Typography variant="body2">
-              <DateTime dt={event.datetimeperiod[0]} />
+              {event.startTime}
             </Typography>
             <Box mx={1}>-</Box>
             <Typography variant="body2">
-              <DateTime dt={event.datetimeperiod[1]} />
+              {event.endTime}
             </Typography>
           </Box>
 

--- a/src/components/events/EventDetails.jsx
+++ b/src/components/events/EventDetails.jsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { Divider, Card, Stack, Box, Grid, Typography } from "@mui/material";
 
 import { locationLabel } from "utils/formatEvent";
+import { shortDateStr  } from "utils/formatTime";
 
 import ClubButton from "components/clubs/ClubButton";
 import EventPoster from "components/events/EventPoster";
@@ -41,11 +42,11 @@ export default function EventDetails({ event, showCode = false }) {
           <Box display="flex" alignItems="center">
             <Icon variant="calendar-today" sx={{ mr: 2, width: 16 }} />
             <Typography variant="body2">
-              {event.startTime}
+              {shortDateStr(event?.startTime)}
             </Typography>
             <Box mx={1}>-</Box>
             <Typography variant="body2">
-              {event.endTime}
+              {shortDateStr(event?.endTime)} (IST)
             </Typography>
           </Box>
 

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -609,6 +609,7 @@ function EventDatetimeInput({
   role = "public",
 }) {
   const startDateInput = watch("startTime");
+  const endDateInput = watch("endTime");
   const [error, setError] = useState(null);
 
   const errorMessage = useMemo(() => {
@@ -626,6 +627,13 @@ function EventDatetimeInput({
   }, [error]);
 
   return (
+  <>
+    <Typography
+      color="text.secondary"
+      sx={{fontSize: '1', textAlign: 'center', marginBottom: '20px', fontWeight: 100}}
+    >
+      (All times are in IST)
+    </Typography>
     <Grid container spacing={2}>
       <Grid item xs={6} xl={4}>
         <Controller
@@ -652,6 +660,11 @@ function EventDatetimeInput({
                 minutes: renderTimeViewClock,
                 seconds: renderTimeViewClock,
               }}
+              maxDateTime={
+                endDateInput
+                  ? dayjs(endDateInput).subtract(1,"minute")
+                  : null
+              }
               sx={{ width: "100%" }}
               value={
                 value instanceof Date && !isDayjs(value) ? dayjs(value) : value
@@ -661,7 +674,7 @@ function EventDatetimeInput({
             />
           )}
         />
-      </Grid>
+	      </Grid>
       <Grid item xs xl={4}>
         <Controller
           name="endTime"
@@ -690,7 +703,6 @@ function EventDatetimeInput({
                   : null
               }
               disablePast={!allowed_roles.includes(role)}
-              onError={(error) => setError(error)}
               slotProps={{
                 textField: {
                   error: errorMessage || invalid,
@@ -712,6 +724,7 @@ function EventDatetimeInput({
         />
       </Grid>
     </Grid>
+  </>
   );
 }
 

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -42,6 +42,7 @@ import MemberListItem from "components/members/MemberListItem";
 
 import { uploadFile } from "utils/files";
 import { audienceMap } from "constants/events";
+import { getDuration, getDateStr } from "utils/formatTime";
 import { locationLabel } from "utils/formatEvent";
 import { useAuth } from "components/AuthProvider";
 
@@ -230,9 +231,11 @@ export default function EventForm({
           : null;
 
     // convert dates to ISO strings
-    data.datetimeperiod = formData.datetimeperiod.map((d) =>
-      new Date(d).toISOString(),
-    );
+    data.startTime = getDateStr(formData.startTime)
+    data.endTime = getDateStr(formData.endTime)
+
+    // get duration from startTime and endTime
+    data.duration = getDuration(formData.startTime, formData.endTime)
 
     // convert budget to array of objects with only required attributes
     // remove budget items without a description (they're invalid)
@@ -330,8 +333,8 @@ export default function EventForm({
                     setHasPhone={setHasPhone}
                     disabled={
                       defaultValues?.status?.state == "approved" &&
-                      defaultValues?.datetimeperiod[0] &&
-                      new Date(defaultValues?.datetimeperiod[0]) < new Date()
+                      defaultValues?.startTime &&
+                      new Date(defaultValues?.startTime) < new Date()
                     }
                   />
                 </Grid>
@@ -605,7 +608,7 @@ function EventDatetimeInput({
   disabled = true,
   role = "public",
 }) {
-  const startDateInput = watch("datetimeperiod.0");
+  const startDateInput = watch("startTime");
   const [error, setError] = useState(null);
 
   const errorMessage = useMemo(() => {
@@ -626,7 +629,7 @@ function EventDatetimeInput({
     <Grid container spacing={2}>
       <Grid item xs={6} xl={4}>
         <Controller
-          name="datetimeperiod.0"
+          name="startTime"
           control={control}
           rules={{
             required: "Start date is required!",
@@ -661,7 +664,7 @@ function EventDatetimeInput({
       </Grid>
       <Grid item xs xl={4}>
         <Controller
-          name="datetimeperiod.1"
+          name="endTime"
           control={control}
           rules={{
             required: "End date is required!",
@@ -819,8 +822,8 @@ function EventVenueInput({
 }) {
   const modeInput = watch("mode");
   const locationInput = watch("location");
-  const startDateInput = watch("datetimeperiod.0");
-  const endDateInput = watch("datetimeperiod.1");
+  const startDateInput = watch("startTime");
+  const endDateInput = watch("endTime");
 
   // reset location if datetime changes
   useEffect(() => resetField("location"), [startDateInput, endDateInput]);

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -674,7 +674,7 @@ function EventDatetimeInput({
             />
           )}
         />
-	      </Grid>
+      </Grid>
       <Grid item xs xl={4}>
         <Controller
           name="endTime"

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -610,12 +610,13 @@ function EventDatetimeInput({
 }) {
   const startDateInput = watch("startTime");
   const endDateInput = watch("endTime");
-  const [error, setError] = useState(null);
+  const [startError, setStartError] = useState(null);
+  const [endError, setEndError] = useState(null);
 
-  const errorMessage = useMemo(() => {
-    switch (error) {
-      case "minDate": {
-        return "An event can not end before it starts!";
+  const startErrorMessage = useMemo(() => {
+    switch (startError) {
+      case "maxDate": {
+        return "Event cannot start after it end!";
       }
       case "invalidDate": {
         return "Invalid date!";
@@ -624,7 +625,22 @@ function EventDatetimeInput({
         return "";
       }
     }
-  }, [error]);
+  }, [startError]);
+
+  const endErrorMessage = useMemo(() => {
+    switch (endError) {
+      case "minDate": {
+        return "Event cannot end before it starts!";
+      }
+      case "invalidDate": {
+        return "Invalid date!";
+      }
+      default: {
+        return "";
+      }
+    }
+  }, [endError]);
+
 
   return (
   <>
@@ -632,7 +648,7 @@ function EventDatetimeInput({
       color="text.secondary"
       sx={{fontSize: '1', textAlign: 'center', marginBottom: '20px', fontWeight: 100}}
     >
-      (All times are in IST)
+      (Date-Time Fields are assumed to be in IST)
     </Typography>
     <Grid container spacing={2}>
       <Grid item xs={6} xl={4}>
@@ -641,17 +657,26 @@ function EventDatetimeInput({
           control={control}
           rules={{
             required: "Start date is required!",
-          }}
+            validate: {
+              checkDate: (value) => {
+                return (
+                  dayjs(value) <= dayjs(endDateInput) ||
+                  "Event must start before it ends!"
+                );
+              },
+	    }
+	  }}
           render={({
             field: { value, ...rest },
             fieldState: { error, invalid },
           }) => (
             <DateTimePicker
               label="Starts *"
+              onError={(error) => setStartError(error)}
               slotProps={{
                 textField: {
-                  error: invalid,
-                  helperText: error?.message,
+                  error: startErrorMessage || invalid,
+                  helperText: startErrorMessage || error?.message,
                 },
               }}
               disablePast={!allowed_roles.includes(role)}
@@ -666,9 +691,7 @@ function EventDatetimeInput({
                   : null
               }
               sx={{ width: "100%" }}
-              value={
-                value instanceof Date && !isDayjs(value) ? dayjs(value) : value
-              }
+              sx={{ width: "100%" }}
               disabled={disabled}
               {...rest}
             />
@@ -703,10 +726,11 @@ function EventDatetimeInput({
                   : null
               }
               disablePast={!allowed_roles.includes(role)}
+              onError={(error) => setEndError(error)}
               slotProps={{
                 textField: {
-                  error: errorMessage || invalid,
-                  helperText: errorMessage || error?.message,
+                  error: endErrorMessage || invalid,
+                  helperText: endErrorMessage || error?.message,
                 },
               }}
               viewRenderers={{
@@ -715,9 +739,6 @@ function EventDatetimeInput({
                 seconds: renderTimeViewClock,
               }}
               sx={{ width: "100%" }}
-              value={
-                value instanceof Date && !isDayjs(value) ? dayjs(value) : value
-              }
               {...rest}
             />
           )}

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -686,10 +686,7 @@ function EventDatetimeInput({
               disabled={!startDateInput || disabled}
               minDateTime={
                 startDateInput
-                  ? (startDateInput instanceof Date && !isDayjs(startDateInput)
-                      ? dayjs(startDateInput)
-                      : startDateInput
-                    ).add(1, "minute")
+                  ? dayjs(startDateInput).add(1,"minute")
                   : null
               }
               disablePast={!allowed_roles.includes(role)}

--- a/src/components/events/EventsGrid.jsx
+++ b/src/components/events/EventsGrid.jsx
@@ -25,7 +25,8 @@ export default async function EventsGrid({
               <EventCard
                 _id={event._id}
                 name={event.name}
-                datetimeperiod={event.datetimeperiod}
+		startTime={event.startTime}
+		endTime={event.endTime}
                 poster={event.poster}
                 clubid={event.clubid}
               />

--- a/src/components/events/EventsTable.jsx
+++ b/src/components/events/EventsTable.jsx
@@ -7,7 +7,7 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { DataGrid, GridLogicOperator } from "@mui/x-data-grid";
 
-import { ISOtoHuman } from "utils/formatTime";
+import { appendWeekday } from "utils/formatTime";
 import { stateLabel } from "utils/formatEvent";
 
 import Tag from "components/Tag";
@@ -78,8 +78,8 @@ export default function EventsTable({
             flex: 3,
             align: "center",
             headerAlign: "center",
-            valueGetter: ({ row }) => row.datetimeperiod[0],
-            valueFormatter: ({ value }) => ISOtoHuman(value),
+            valueGetter: ({ row }) => row.startTime,
+            valueFormatter: ({ value }) => appendWeekday(value),
           },
         ]),
     // {
@@ -148,7 +148,7 @@ export default function EventsTable({
       headerAlign: "center",
       valueGetter: ({ row }) => ({
         state: row.status.state,
-        start: row.datetimeperiod[0],
+        start: row.startTime,
       }),
       renderCell: ({ value }) => {
         // change state to 'completed' if it has been approved and is in the past

--- a/src/components/events/EventsTable.jsx
+++ b/src/components/events/EventsTable.jsx
@@ -7,7 +7,7 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { DataGrid, GridLogicOperator } from "@mui/x-data-grid";
 
-import { appendWeekday } from "utils/formatTime";
+import { shortDateStr } from "utils/formatTime";
 import { stateLabel } from "utils/formatEvent";
 
 import Tag from "components/Tag";
@@ -79,7 +79,7 @@ export default function EventsTable({
             align: "center",
             headerAlign: "center",
             valueGetter: ({ row }) => row.startTime,
-            valueFormatter: ({ value }) => appendWeekday(value),
+            valueFormatter: ({ value }) => shortDateStr(value),
           },
         ]),
     // {

--- a/src/gql/queries/events.jsx
+++ b/src/gql/queries/events.jsx
@@ -17,7 +17,8 @@ export const GET_CLUB_EVENTS = gql`
       name
       code
       clubid
-      datetimeperiod
+      startTime
+      endTime
       poster
       status {
         state
@@ -36,7 +37,8 @@ export const GET_PENDING_EVENTS = gql`
       name
       code
       clubid
-      datetimeperiod
+      startTime
+      endTime
       status {
         state
         room
@@ -58,7 +60,8 @@ export const GET_ALL_EVENTS = gql`
       name
       code
       clubid
-      datetimeperiod
+      startTime
+      endTime
       status {
         state
         room
@@ -83,7 +86,8 @@ export const GET_EVENT = gql`
       location
       audience
       description
-      datetimeperiod
+      startTime
+      endTime
       link
       poster
       mode
@@ -105,7 +109,8 @@ export const GET_FULL_EVENT = gql`
         advance
       }
       clubid
-      datetimeperiod
+      startTime
+      endTime
       description
       equipment
       link
@@ -124,8 +129,8 @@ export const GET_FULL_EVENT = gql`
 `;
 
 export const GET_AVAILABLE_LOCATIONS = gql`
-  query AvailableRooms($timeslot: [DateTime!]!, $eventid: String) {
-    availableRooms(timeslot: $timeslot, eventid: $eventid) {
+  query AvailableRooms($startTime: String!, $endTime: String!, $eventid: String) {
+    availableRooms(inputStart: $startTime, inputEnd: $endTime, eventid: $eventid) {
       locations
     }
   }

--- a/src/utils/formatTime.jsx
+++ b/src/utils/formatTime.jsx
@@ -1,25 +1,35 @@
-"use client";
+"do not use client! just fix IST for everything";
 
-const LOCALE = "en-IN";
+export function appendWeekday(date) {
+  const dateObj = getDateObj(dateString)
+  const formatter = new Intl.DateTimeFormat('en-US', { weekday: 'long' });
+  const weekday = formatter.format(dateObj);
 
-// get datetime components from ISO string
-export function ISOtoDateTime(iso) {
-  const dt = new Date(iso);
-
-  const options = { hour12: true };
-  return {
-    weekday: dt.toLocaleString(LOCALE, { weekday: "short", ...options }),
-    day: dt.toLocaleString(LOCALE, { day: "numeric", ...options }),
-    month: dt.toLocaleString(LOCALE, { month: "short", ...options }),
-    year: dt.toLocaleString(LOCALE, { year: "numeric", ...options }),
-    time: dt.toLocaleString(LOCALE, { timeStyle: "short", ...options }),
-  };
+  return `${weekday} ${date}`;
 }
 
-// get human readable date time from ISO string
-export function ISOtoHuman(iso, weekDay = false) {
-  const dt = ISOtoDateTime(iso);
-  return `${weekDay ? `${dt.weekday} ` : ""}${dt.day} ${dt.month}${
-    dt.year !== String(new Date().getFullYear()) ? ` ${dt.year}` : ""
-  }, ${dt.time.toUpperCase()}`;
+export function getDateObj(dateStr){
+  // use regex to record arguments and pass into Date()
+  return new Date(dateStr.replace(/(\d{2})-(\d{2})-(\d{4}) (\d{2}):(\d{2})/, "$3-$2-$1T$4:$5"))
+}
+
+export function getDateStr(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${day}-${month}-${year} ${hours}:${minutes}`;
+}
+
+export function getDuration(startDate, endDate) {
+  const duration = endDate - startDate;
+  const hours = Math.floor(duration / (1000 * 60 * 60));
+  const minutes = Math.floor((duration % (1000 * 60 * 60)) / (1000 * 60));
+
+  const formattedHours = String(hours).padStart(2, '0');
+  const formattedMinutes = String(minutes).padStart(2, '0');
+
+  return `${formattedHours}:${formattedMinutes}`;
 }

--- a/src/utils/formatTime.jsx
+++ b/src/utils/formatTime.jsx
@@ -1,11 +1,33 @@
 "do not use client! just fix IST for everything";
+import dayjs from "dayjs";
 
-export function appendWeekday(date) {
-  const dateObj = getDateObj(dateString)
-  const formatter = new Intl.DateTimeFormat('en-US', { weekday: 'long' });
-  const weekday = formatter.format(dateObj);
+export function appendWeekday(dateString) {
+  const dateObj = getDateObj(dateString);
+  console.log(dateObj);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true
+  });
+  const formattedDate = formatter.format(dateObj);
+  return String(formattedDate);
+}
 
-  return `${weekday} ${date}`;
+export function shortDateStr(dateString) {
+  const dateObj = getDateObj(dateString);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true,
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const formattedDate = formatter.format(dateObj);
+  return String(formattedDate);
 }
 
 export function getDateObj(dateStr){
@@ -14,19 +36,17 @@ export function getDateObj(dateStr){
 }
 
 export function getDateStr(date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-
-  return `${day}-${month}-${year} ${hours}:${minutes}`;
+  const dayjsDate = dayjs(date);
+  return dayjsDate.format('DD-MM-YYYY HH:mm');
 }
 
 export function getDuration(startDate, endDate) {
-  const duration = endDate - startDate;
-  const hours = Math.floor(duration / (1000 * 60 * 60));
-  const minutes = Math.floor((duration % (1000 * 60 * 60)) / (1000 * 60));
+  const start = dayjs(startDate);
+  const end = dayjs(endDate);
+
+  const diffInSeconds = end.diff(start, 'seconds');
+  const hours = Math.floor(diffInSeconds / 3600);
+  const minutes = Math.floor((diffInSeconds % 3600) / 60);
 
   const formattedHours = String(hours).padStart(2, '0');
   const formattedMinutes = String(minutes).padStart(2, '0');


### PR DESCRIPTION
## Overview

The current way of storing DateTime elements in the database is causing database corruption.
Storing strings in the datetime period feels more safe and also prevents other timezone problems like #48 
from happening.

## Changes Proposed

1. Store times as string without any timezone data, assuming everything as IST.
2. Store timings of event as two variables, rather than a tuple, to prevent any unwanted confusion in db
3. Store duration of the event for security for now. It will not be used currently anywhere, except if needed to restore corruption in db in times of the events

## Linked PRs

- Events: https://github.com/Clubs-Council-IIITH/events/pull/29