### PR TITLE
Add support for approval and creation times in the members

### DIFF
--- a/src/app/manage/members/[id]/page.jsx
+++ b/src/app/manage/members/[id]/page.jsx
@@ -31,14 +31,16 @@ export default async function ManageMember({ params }) {
       },
     });
 
+    if (userProfile === null || userMeta === null) {
+      return redirect("/404");
+    }
+
     // fetch currently logged in user
     const {
       data: { userMeta: currentUserMeta, userProfile: currentUserProfile } = {},
     } = await getClient().query(GET_USER, { userInput: null });
     const user = { ...currentUserMeta, ...currentUserProfile };
-    if (userProfile === null || userMeta === null) {
-      return redirect("/404");
-    }
+
     return (
       <Container>
         <MemberActionsList member={member} user={user} />
@@ -113,38 +115,40 @@ export default async function ManageMember({ params }) {
               />
             </Grid>
           </Grid>
-          {user?.role == "cc" ? (
-            <Grid item container xs spacing={1} mt={5}>
-              <Grid item xs>
-                <Typography
-                  variant="subtitle2"
-                  textTransform="uppercase"
-                  gutterBottom
-                >
-                  Creation Time
-                </Typography>
-                <Typography variant="body" color="#777777" fontWeight="100">
-                  {member.creationTime ? member.creationTime : "Info Not Available"}
-                </Typography>
-              </Grid>
-              <Grid item xs>
-                <Typography
-                  variant="subtitle2"
-                  textTransform="uppercase"
-                  gutterBottom
-                >
-                  Last Edited
-                </Typography>
-                <Typography variant="body" color="#777777" fontWeight="100">
-                  {member.creationTime ? member.creationTime : "Info Not Available"}
-                </Typography>
-              </Grid>
-            </Grid>)
-          : null}
+          <Grid item container xs spacing={1} mt={5}>
+            <Grid item xs={12} md={6}>
+              <Typography
+                variant="subtitle2"
+                textTransform="uppercase"
+                gutterBottom
+              >
+                Creation Time
+              </Typography>
+              <Typography variant="body" color="#777777" fontWeight="100">
+                {member.creationTime
+                  ? member.creationTime
+                  : "Information Not Available"}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography
+                variant="subtitle2"
+                textTransform="uppercase"
+                gutterBottom
+              >
+                Last Edited Time
+              </Typography>
+              <Typography variant="body" color="#777777" fontWeight="100">
+                {member.lastEditedTime
+                  ? member.lastEditedTime
+                  : "Information Not Available"}
+              </Typography>
+            </Grid>
+          </Grid>
         </Grid>
       </Container>
     );
   } catch (error) {
-    redirect("/404");
+    return redirect("/404");
   }
 }

--- a/src/app/manage/members/[id]/page.jsx
+++ b/src/app/manage/members/[id]/page.jsx
@@ -113,6 +113,34 @@ export default async function ManageMember({ params }) {
               />
             </Grid>
           </Grid>
+          {user?.role == "cc" ? (
+            <Grid item container xs spacing={1} mt={5}>
+              <Grid item xs>
+                <Typography
+                  variant="subtitle2"
+                  textTransform="uppercase"
+                  gutterBottom
+                >
+                  Creation Time
+                </Typography>
+                <Typography variant="body" color="#777777" fontWeight="100">
+                  {member.creationTime ? member.creationTime : "Info Not Available"}
+                </Typography>
+              </Grid>
+              <Grid item xs>
+                <Typography
+                  variant="subtitle2"
+                  textTransform="uppercase"
+                  gutterBottom
+                >
+                  Last Edited
+                </Typography>
+                <Typography variant="body" color="#777777" fontWeight="100">
+                  {member.creationTime ? member.creationTime : "Info Not Available"}
+                </Typography>
+              </Grid>
+            </Grid>)
+          : null}
         </Grid>
       </Container>
     );

--- a/src/components/members/MemberPositions.jsx
+++ b/src/components/members/MemberPositions.jsx
@@ -95,6 +95,7 @@ export default function MemberPositions({
       headerName: "Role",
       flex: isMobile ? null : 4,
       editable: editable,
+
       renderCell: (p) =>
         p.value ? (
           <Typography
@@ -111,6 +112,7 @@ export default function MemberPositions({
             }}
           >
             {p.value}
+
           </Typography>
         ) : (
           <Typography color="text.secondary">
@@ -159,16 +161,30 @@ export default function MemberPositions({
             flex: isMobile ? null : 2,
             valueGetter: ({ row }) => ({
               approved: row.approved,
+	      approvalTime: row.approvalTime,
               rejected: row.rejected,
+	      rejectionTime: row.rejectionTime,
             }),
-            renderCell: ({ value: { approved, rejected } }) => (
-              <Tag
-                label={
-                  approved ? "Approved" : rejected ? "Rejected" : "Pending"
-                }
-                color={approved ? "success" : rejected ? "error" : "warning"}
-                sx={{ my: 2 }}
-              />
+            renderCell: ({ value: { approved, approvalTime , rejected, rejectionTime } }) => (
+	      <Tooltip
+                title = {approved
+                  ? (approvalTime || null)
+                  : rejected
+                  ? (rejectedTime || null)
+                  : null
+	        }
+		placement="left-start"
+	      >
+	      <Button size="small">
+                <Tag
+                  label={
+                    approved ? "Approved" : rejected ? "Rejected" : "Pending"
+                  }
+                  color={approved ? "success" : rejected ? "error" : "warning"}
+                  sx={{ my: 2 }}
+                />
+	      </Button>
+	      </Tooltip>
             ),
           },
 

--- a/src/components/members/MemberPositions.jsx
+++ b/src/components/members/MemberPositions.jsx
@@ -112,7 +112,6 @@ export default function MemberPositions({
             }}
           >
             {p.value}
-
           </Typography>
         ) : (
           <Typography color="text.secondary">
@@ -161,30 +160,35 @@ export default function MemberPositions({
             flex: isMobile ? null : 2,
             valueGetter: ({ row }) => ({
               approved: row.approved,
-	      approvalTime: row.approvalTime,
+              approvalTime: row.approvalTime,
               rejected: row.rejected,
-	      rejectionTime: row.rejectionTime,
+              rejectionTime: row.rejectionTime,
             }),
-            renderCell: ({ value: { approved, approvalTime , rejected, rejectionTime } }) => (
-	      <Tooltip
-                title = {approved
-                  ? (approvalTime || null)
-                  : rejected
-                  ? (rejectedTime || null)
-                  : null
-	        }
-		placement="left-start"
-	      >
-	      <Button size="small">
-                <Tag
-                  label={
-                    approved ? "Approved" : rejected ? "Rejected" : "Pending"
-                  }
-                  color={approved ? "success" : rejected ? "error" : "warning"}
-                  sx={{ my: 2 }}
-                />
-	      </Button>
-	      </Tooltip>
+            renderCell: ({
+              value: { approved, approvalTime, rejected, rejectionTime },
+            }) => (
+              <Tooltip
+                title={
+                  approved
+                    ? approvalTime || "No Information Available"
+                    : rejected
+                    ? rejectionTime || "No Information Available"
+                    : null
+                }
+                placement="left-start"
+              >
+                <span>
+                  <Tag
+                    label={
+                      approved ? "Approved" : rejected ? "Rejected" : "Pending"
+                    }
+                    color={
+                      approved ? "success" : rejected ? "error" : "warning"
+                    }
+                    sx={{ my: 2 }}
+                  />
+                </span>
+              </Tooltip>
             ),
           },
 

--- a/src/gql/queries/members.jsx
+++ b/src/gql/queries/members.jsx
@@ -72,8 +72,12 @@ export const GET_MEMBER = gql`
         endYear
         deleted
         approved
+	approvalTime
         rejected
+	rejectionTime
       }
+      creationTime
+      lastEditedTime
     }
     userProfile(userInput: $userInput) {
       firstName

--- a/src/gql/queries/members.jsx
+++ b/src/gql/queries/members.jsx
@@ -72,9 +72,9 @@ export const GET_MEMBER = gql`
         endYear
         deleted
         approved
-	approvalTime
+        approvalTime
         rejected
-	rejectionTime
+        rejectionTime
       }
       creationTime
       lastEditedTime


### PR DESCRIPTION
## Changes
This PR aims to add a provision for tracking timestamps of when 
- club added a new member.
- when its role was approved by CC.
- when it was last edited.

As stated by CC, this info will be useful for security purposes and avoid looking through emails.

## Usage

- To get the approval time of any role. Just hover over one of the Approval Icon Tags. This works for both
  approval time and rejection time.
![ss](https://github.com/user-attachments/assets/a6c53618-9dc2-412a-a759-0a830dd191f1)

- For the `Creation Time` and `Last Updated time` here, I have added a grid at the bottom. WHICH IS ONLY VIEWABLE BY CC.
![ss](https://github.com/user-attachments/assets/06dc818f-a252-4bcc-ae96-f533f3abe033)


## Linked PRs

- Members: https://github.com/Clubs-Council-IIITH/members/pull/7

