### PR TITLE
metadata: add support for og:image in event links

### DIFF
--- a/src/app/events/[id]/page.jsx
+++ b/src/app/events/[id]/page.jsx
@@ -1,19 +1,35 @@
 import { getClient } from "gql/client";
 import { GET_EVENT } from "gql/queries/events";
 import { redirect } from "next/navigation";
+import { headers  } from 'next/headers';
 
 import EventDetails from "components/events/EventDetails";
 
 export async function generateMetadata({ params }, parent) {
   const { id } = params;
-
+  const headersList = headers();
+  const host = headersList.get('host') || '';
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https';
   try {
     const { data: { event } = {} } = await getClient().query(GET_EVENT, {
       eventid: id,
     });
+    const posterUrl = event.poster
+      ? `${protocol}://${host}/files/download?filename=${encodeURIComponent(event.poster)}&w=1080&q=75`
+      : `https://clubs.iiit.ac.in/assets/cc-logo-full-color.svg`;
 
     return {
       title: event.name,
+      openGraph: {
+        images: [
+          {
+            url: posterUrl,
+            width: 256,
+            height: 256,
+            alt: event.name,
+          },
+        ],
+      },
     };
   } catch (error) {
     return redirect("/404");

--- a/src/app/events/[id]/page.jsx
+++ b/src/app/events/[id]/page.jsx
@@ -1,29 +1,28 @@
 import { getClient } from "gql/client";
 import { GET_EVENT } from "gql/queries/events";
 import { redirect } from "next/navigation";
-import { headers  } from 'next/headers';
 
+import { getFile } from "utils/files";
+import { getPlaceholder } from "utils/placeholder";
 import EventDetails from "components/events/EventDetails";
 
 export async function generateMetadata({ params }, parent) {
   const { id } = params;
-  const headersList = headers();
-  const host = headersList.get('host') || '';
-  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https';
+
   try {
     const { data: { event } = {} } = await getClient().query(GET_EVENT, {
       eventid: id,
     });
-    const posterUrl = event.poster
-      ? `${protocol}://${host}/files/download?filename=${encodeURIComponent(event.poster)}&w=1080&q=75`
-      : `https://clubs.iiit.ac.in/assets/cc-logo-color.png`;
+    const img = event.poster
+      ? getFile(event.poster)
+      : getPlaceholder({ seed: event.name, w: 2000, h: 2000 })
 
     return {
       title: event.name,
       openGraph: {
         images: [
           {
-            url: posterUrl,
+            url: img,
             width: 256,
             height: 256,
             alt: event.name,

--- a/src/app/events/[id]/page.jsx
+++ b/src/app/events/[id]/page.jsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }, parent) {
     });
     const posterUrl = event.poster
       ? `${protocol}://${host}/files/download?filename=${encodeURIComponent(event.poster)}&w=1080&q=75`
-      : `https://clubs.iiit.ac.in/assets/cc-logo-full-color.svg`;
+      : `https://clubs.iiit.ac.in/assets/cc-logo-color.png`;
 
     return {
       title: event.name,


### PR DESCRIPTION
## Features

- This adds a thumbnail whenever you send it in platforms like whatsapp or other socials.

## Changes

- Add a new metadata tag for "opengraph-image", `og:image`.
- Construct a URL for the poster and set it to the image metadata tag.