### PR TITLE
Content-Security-Policy: add strict csp headers and use a nonce

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -10,6 +10,7 @@ import { GET_USER } from "gql/queries/auth";
 import { AuthProvider } from "components/AuthProvider";
 import { fontClass } from "components/ThemeRegistry/typography";
 import TransitionProvider from "components/TransitionProvider";
+import { headers } from 'next/headers';
 
 const description =
   "Discover the vibrant campus life at IIIT Hyderabad through the Clubs Council. Explore diverse student-led clubs, and events that foster an inclusive community and enrich student experiences beyond the classroom. Stay updated on activities, events, and opportunities to engage and grow at IIIT-H.";
@@ -53,6 +54,9 @@ export const metadata = {
 };
 
 export default async function RootLayout({ children }) {
+  // get the nonce and use it
+  const nonce = headers().get('x-nonce') || ' ';
+
   // fetch currently logged in user
   const { data: { userMeta, userProfile } = {} } = await getClient().query(
     GET_USER,
@@ -72,7 +76,7 @@ export default async function RootLayout({ children }) {
     <html lang="en">
       <body className={fontClass}>
         <ModeProvider>
-          <ThemeRegistry>
+          <ThemeRegistry nonce={nonce}>
             <Progressbar />
             <LocalizationWrapper>
               <AuthProvider user={user}>

--- a/src/components/ThemeRegistry/EmotionCache.jsx
+++ b/src/components/ThemeRegistry/EmotionCache.jsx
@@ -7,7 +7,7 @@ import { CacheProvider as DefaultCacheProvider } from "@emotion/react";
 
 // This implementation is taken from https://github.com/garronej/tss-react/blob/main/src/next/appDir.tsx
 export default function NextAppDirEmotionCacheProvider(props) {
-  const { options, CacheProvider = DefaultCacheProvider, children } = props;
+  const { options, CacheProvider = DefaultCacheProvider, nonce, children } = props;
 
   const [{ cache, flush }] = React.useState(() => {
     // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -44,6 +44,7 @@ export default function NextAppDirEmotionCacheProvider(props) {
     return (
       <style
         key={cache.key}
+        nonce={nonce}
         data-emotion={`${cache.key} ${names.join(" ")}`}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{

--- a/src/components/ThemeRegistry/ThemeRegistry.jsx
+++ b/src/components/ThemeRegistry/ThemeRegistry.jsx
@@ -12,7 +12,7 @@ import breakpoints from "./breakpoints";
 import componentsOverride from "./overrides";
 import shadows, { customShadows } from "./shadows";
 
-export default function ThemeRegistry({ children }) {
+export default function ThemeRegistry({ children, nonce }) {
   const prefersDarkMode = useMode();
 
   const themeOptions = React.useMemo(
@@ -33,7 +33,7 @@ export default function ThemeRegistry({ children }) {
   theme.components = componentsOverride(theme);
 
   return (
-    <NextAppDirEmotionCacheProvider options={{ key: "mui" }}>
+    <NextAppDirEmotionCacheProvider options={{ key: "mui", nonce: nonce }}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         {children}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -7,33 +7,86 @@ import clubRedirects from "acl/clubRedirects";
 
 // TODO: make multiple middlewares (one for route acl, one for club redirects) and combine them
 export function middleware(req) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const { pathname } = req.nextUrl;
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https: http: 'unsafe-inline' ${
+      process.env.NODE_ENV === "production" ? "" : `'unsafe-eval'`
+    };
+    style-src 'self' 'nonce-${nonce}';
+    img-src 'self' blob: data:;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+  `;
+
+  // Replace newline characters and spaces
+  const contentSecurityPolicyHeaderValue = cspHeader
+    .replace(/\s{2,}/g, " ")
+    .trim();
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set(
+    "Content-Security-Policy",
+    contentSecurityPolicyHeaderValue,
+  );
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.headers.set(
+    "Content-Security-Policy",
+    contentSecurityPolicyHeaderValue,
+  );
+
   // if logout cookie is set, log the user out
   if (req.cookies.has("logout")) {
     // clear logout cookie
     req.cookies.delete("logout");
-
-    return NextResponse.redirect(new URL("/logoutCallback", req.url));
+    const redirectRes = NextResponse.redirect(new URL("/logoutCallback", req.url));
+    redirectRes.headers.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue,
+    );
+    return redirectRes;
   }
 
   // redirect to CC about page
-  if (req.nextUrl.pathname === "/student-bodies/clubs") {
-    return NextResponse.redirect(new URL("/about/clubs-council", req.url));
+  if (pathname === "/student-bodies/clubs") {
+    const redirectRes =  NextResponse.redirect(new URL("/about/clubs-council", req.url));
+    redirectRes.headers.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue,
+    );
+    return redirectRes;
   }
 
   // check if current route is protected
   const protectedRoute =
-    Object.keys(routes).find((r) => match(r)(req.nextUrl.pathname)) || false;
+    Object.keys(routes).find((r) => match(r)(pathname)) || false;
 
   // if not, proceed to the page
   if (!protectedRoute) {
-    return NextResponse.next();
+    return response;
   }
 
   // if protected and current user is not logged in, redirect to login page
   if (!req.cookies.has("Authorization")) {
-    return NextResponse.redirect(
-      new URL(`/login${req.nextUrl.pathname}`, req.url),
+    const redirectRes = NextResponse.redirect(
+      new URL(`/login${pathname}`, req.url),
     );
+    redirectRes.headers.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue,
+    );
+    return redirectRes;
   }
 
   // if logged in, extract user attributes
@@ -42,22 +95,51 @@ export function middleware(req) {
 
   // check if current route is to be redirected for club accounts
   const clubRedirectRoute =
-    Object.keys(clubRedirects).find((r) => match(r)(req.nextUrl.pathname)) ||
+    Object.keys(clubRedirects).find((r) => match(r)(pathname)) ||
     false;
 
   // club account specific redirects
   if (clubRedirectRoute && user?.role === "club") {
-    return NextResponse.redirect(
-      new URL(clubRedirects[req.nextUrl.pathname], req.url),
+    const redirectRes = NextResponse.redirect(
+      new URL(clubRedirects[pathname], req.url),
     );
+    redirectRes.headers.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue,
+    );
+    return redirectRes;
   }
 
   // check if user has access to route
   if (!routes[protectedRoute].includes(user?.role)) {
     // redirect to home page if user does not have access
-    return NextResponse.redirect(new URL("/", req.url));
+    const redirectRes = NextResponse.redirect(new URL("/", req.url));
+    redirectRes.headers.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue,
+    );
+    return redirectRes;
   }
 
   // continue to page
-  return NextResponse.next();
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
## Need for Changes

- The latest google lighthouse report has shown how we allow `unsafe-inline` styles and
  basically have no CSP in place.

According to [nextjs docs](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy) it is recommended to add these headers to the middleware and wherever
needed (when external scripts or inline scripts are being called), add the nonce instead
to uniquely generate a nonce everytime the page loads.

- Since we are using MUI, [their docs](https://mui.com/material-ui/guides/content-security-policy/), instruct
  addind nonce to the ThemeRegistry using aa cache provider.

## Changes

- I have added some strict headers and made some changes so the redirects also return these headers.
- I have included the nonce in the `ThemeRegistry` style tag, and the subsequent `CacheProvider` to cache it out.
- I have added `*.iiit.ac.in`, as a white list to `<iframe>` as long as it is being displayed in the [iiit website](iiit.ac.in).
- Added nonce to some of the in-line style tags used in the repo.