### PR TITLE
events: add a new action to reject event for cc

### DIFF
--- a/src/actions/events/edit/server_action.jsx
+++ b/src/actions/events/edit/server_action.jsx
@@ -7,7 +7,7 @@ export async function editEventAction(details, eventid) {
   const response = { ok: false, data: null, error: null };
 
   const {
-    data: { editEvent },
+    data,
     error,
   } = await getClient().mutation(EDIT_EVENT, {
     details: { ...details, eventid },
@@ -19,7 +19,7 @@ export async function editEventAction(details, eventid) {
     };
   } else {
     response.ok = true;
-    response.data = editEvent;
+    response.data = data.editEvent;
   }
 
   return response;

--- a/src/actions/events/reject/server_action.jsx
+++ b/src/actions/events/reject/server_action.jsx
@@ -1,0 +1,24 @@
+"use server";
+
+import { getClient } from "gql/client";
+import { REJECT_EVENT } from "gql/mutations/events";
+
+export async function rejectEventAction(data) {
+  const {eventid, reason} = data;
+  const response = { ok: false, error: null };
+
+  const { error } = await getClient().mutation(REJECT_EVENT, {
+    eventid,
+    reason,
+  });
+  if (error) {
+    response.error = {
+      title: error.name,
+      messages: error?.graphQLErrors?.map((ge) => ge?.message),
+    };
+  } else {
+    response.ok = true;
+  }
+
+  return response;
+}

--- a/src/actions/events/venues/server_action.jsx
+++ b/src/actions/events/venues/server_action.jsx
@@ -8,7 +8,7 @@ export async function eventsVenues(data) {
   const { startDate, endDate, eventid } = data;
 
   const {
-    data: { availableRooms },
+    data: outputData,
     error,
   } = await getClient().query(GET_AVAILABLE_LOCATIONS, {
     timeslot: [startDate, endDate],
@@ -21,7 +21,7 @@ export async function eventsVenues(data) {
     };
   } else {
     response.ok = true;
-    response.data = availableRooms;
+    response.data = outputData.availableRooms;
   }
 
   return response;

--- a/src/app/manage/events/[id]/approve_cc/page.jsx
+++ b/src/app/manage/events/[id]/approve_cc/page.jsx
@@ -8,11 +8,13 @@ import { Container, Typography } from "@mui/material";
 
 import { techTeamWords } from "constants/ccMembersFilterWords";
 import { extractFirstYear } from "components/members/MembersGrid";
-import EventApproveForm from "components/events/EventApproveForm";
+import EventActionTabs from "components/events/EventActionTabs";
+
 
 export const metadata = {
-  title: "Approve Event | CC",
+  title: "Approve/Reject Event | CC",
 };
+
 
 export default async function ApproveEventCC({ params }) {
   const { id } = params;
@@ -60,11 +62,11 @@ export default async function ApproveEventCC({ params }) {
       <Container>
         <center>
           <Typography variant="h3" gutterBottom mb={3}>
-            Approve Event | Clubs Council
+            Approve or Reject Event | Clubs Council
           </Typography>
         </center>
 
-        <EventApproveForm eventid={event._id} members={currentccMembers} />
+	<EventActionTabs eventid={event._id} members={currentccMembers} />
       </Container>
     )
   );

--- a/src/app/manage/events/[id]/page.jsx
+++ b/src/app/manage/events/[id]/page.jsx
@@ -20,6 +20,7 @@ import {
   EditEvent,
   CopyEvent,
   ApproveEvent,
+  ProgressEvent,
   DeleteEvent,
   SubmitEvent,
   EditFinances,
@@ -518,13 +519,13 @@ function getActions(event, user) {
   }
 
   /*
-   * CC - pending approval - approve, edit, delete
+   * CC - pending approval - progress, edit, delete
    * CC - not incomplete event - delete, edit, copy
    * CC - incomplete event - edit
    */
   if (user?.role === "cc") {
     if (event?.status?.state === "pending_cc")
-      return [ApproveEvent, EditEvent, DeleteEvent];
+      return [ProgressEvent, EditEvent, DeleteEvent];
     else if (event?.status?.state !== "incomplete")
       return [EditEvent, DeleteEvent, CopyEvent];
     else return [EditEvent];

--- a/src/components/FileUpload.jsx
+++ b/src/components/FileUpload.jsx
@@ -45,11 +45,11 @@ export default function FileUpload({
 }
 
 function getIsTypeofFileRejected(fileRejections, type) {
-  console.log(
-    fileRejections.some(({ errors }) =>
-      errors.some((error) => error.code == type),
-    ),
-  );
+  // console.log(
+  //   fileRejections.some(({ errors }) =>
+  //     errors.some((error) => error.code == type),
+  //   ),
+  // );
   return fileRejections.some(({ errors }) =>
     errors.some((error) => error.code == type),
   );

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -74,10 +74,12 @@ function Bar({ onOpenDrawer }) {
 
         <Stack
           direction="row"
-          alignItems="center"
           spacing={{
             xs: 0.5,
             sm: 1,
+          }}
+          sx={{
+            alignItems: "center",
           }}
         >
           <AccountPopover />

--- a/src/components/events/EventActionTabs.jsx
+++ b/src/components/events/EventActionTabs.jsx
@@ -260,7 +260,7 @@ function EventRejectForm({ eventid }) {
 
   const { control, handleSubmit } = useForm({
     defaultValues: {
-      reason: "As requested by the Club to make more edits.",
+      reason: "Some logical & valid reason...",
     },
   });
 

--- a/src/components/events/EventActions.jsx
+++ b/src/components/events/EventActions.jsx
@@ -9,9 +9,7 @@ import { Button } from "@mui/material";
 
 import Icon from "components/Icon";
 import ConfirmDialog from "components/ConfirmDialog";
-
 import { useToast } from "components/Toast";
-import { useAuth } from "components/AuthProvider";
 
 import { deleteEventAction } from "actions/events/delete/server_action";
 import { eventProgress } from "actions/events/progress/server_action";
@@ -213,7 +211,6 @@ export function ApproveEvent({ sx }) {
 }
 
 export function ProgressEvent({ sx }) {
-  const router = useRouter();
   const { id } = useParams();
   return (
     <Button

--- a/src/components/events/EventActions.jsx
+++ b/src/components/events/EventActions.jsx
@@ -162,7 +162,6 @@ export function SubmitEvent({ sx }) {
 export function ApproveEvent({ sx }) {
   const router = useRouter();
   const { id } = useParams();
-  const { user } = useAuth();
   const { triggerToast } = useToast();
   const [dialog, setDialog] = useState(false);
 
@@ -190,41 +189,42 @@ export function ApproveEvent({ sx }) {
 
   return (
     <>
-      {/* If user?.role === "cc", then redirect to /manage/events/id/approve_cc */}
-      {user && user.role === "cc" ? (
-        <Button
-          component={Link}
-          href={`/manage/events/${id}/approve_cc`}
-          variant="contained"
-          color="success"
-          startIcon={<Icon variant="done" />}
-          sx={sx}
-        >
-          Approve
-        </Button>
-      ) : (
-        <>
-          <Button
-            variant="contained"
-            color="success"
-            startIcon={<Icon variant="done" />}
-            onClick={() => setDialog(true)}
-            sx={sx}
-          >
-            Approve
-          </Button>
+      <Button
+        variant="contained"
+        color="success"
+        startIcon={<Icon variant="done" />}
+        onClick={() => setDialog(true)}
+        sx={sx}
+      >
+        Approve
+      </Button>
 
-          <ConfirmDialog
-            open={dialog}
-            title="Are you sure you want to approve this event?"
-            description="This action cannot be undone."
-            onConfirm={approveEvent}
-            onClose={() => setDialog(false)}
-            confirmProps={{ color: "success" }}
-            confirmText="Yes, approve it"
-          />
-        </>
-      )}
+      <ConfirmDialog
+        open={dialog}
+        title="Are you sure you want to approve this event?"
+        description="This action cannot be undone."
+        onConfirm={approveEvent}
+        onClose={() => setDialog(false)}
+        confirmProps={{ color: "success" }}
+        confirmText="Yes, approve it"
+      />
     </>
+  );
+}
+
+export function ProgressEvent({ sx }) {
+  const router = useRouter();
+  const { id } = useParams();
+  return (
+    <Button
+      component={Link}
+      href={`/manage/events/${id}/approve_cc`}
+      variant="contained"
+      color="secondary"
+      startIcon={<Icon variant="add" />}
+      sx={sx}
+    >
+      Progress
+    </Button>
   );
 }

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -90,7 +90,7 @@ export default function EventForm({
     })();
   }, []);
 
-  const { control, handleSubmit, watch, resetField } = useForm({
+  const { control, handleSubmit, watch, resetField, setValue } = useForm({
     defaultValues,
   });
   const { triggerToast } = useToast();
@@ -372,6 +372,7 @@ export default function EventForm({
                 <EventDatetimeInput
                   control={control}
                   watch={watch}
+                  setValue={setValue}
                   disabled={
                     !admin_roles.includes(user?.role) &&
                     defaultValues?.status?.state != undefined &&
@@ -752,6 +753,7 @@ function filterEvents(events, startTime, endTime) {
 function EventDatetimeInput({
   control,
   watch,
+  setValue,
   disabled = true,
   role = "public",
   existingEvents = [],
@@ -775,6 +777,15 @@ function EventDatetimeInput({
       }
     }
   }, [error]);
+
+  useEffect(() => {
+    if (
+      startDateInput &&
+      endDateInput &&
+      dayjs(startDateInput).isAfter(dayjs(endDateInput))
+    )
+      setValue("datetimeperiod.1", null);
+  }, [startDateInput]);
 
   return (
     <Grid container spacing={2}>

--- a/src/gql/mutations/events.jsx
+++ b/src/gql/mutations/events.jsx
@@ -44,6 +44,20 @@ export const PROGRESS_EVENT = gql`
   }
 `;
 
+export const REJECT_EVENT = gql`
+  mutation REJECT_EVENT(
+    $eventid: String!
+    $reason: String!
+  ) {
+    rejectEvent(
+      eventid: $eventid
+      reason: $reason
+    ) {
+      _id
+    }
+  }
+`;
+
 export const UPDATE_BILLS_STATUS = gql`
   mutation UpdateBillsStatus($details: InputBillsStatus!) {
     updateBillsStatus(details: $details) {


### PR DESCRIPTION
## Changes 

- Changed the Approve logic to Progress with both Approve and Rejection available
- remove the EventApproveForm file and replace with a general EventActionTabs
- Add a new component EventRejectionForm which only takes reason as input
- Add a query for above

## Related PR

- Events: https://github.com/Clubs-Council-IIITH/events/pull/48