### PR TITLE
file renaming: fix filerenaming and remove compression logic from frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@svgr/webpack": "^8.1.0",
     "@urql/next": "^1.1.2",
     "add-dependencies": "^1.1.0",
-    "browser-image-resizer": "^2.4.1",
     "cookies-next": "^4.3.0",
     "dayjs": "^1.11.13",
     "framer-motion": "^11.11.9",

--- a/src/utils/files.jsx
+++ b/src/utils/files.jsx
@@ -51,6 +51,14 @@ export async function uploadImageFile(file, filename = null, maxSizeMB = 0.3) {
   const ext = file.name.split(".").pop();
   filename = filename ? `${filename}.${ext}` : file.name;
 
+  // TODO: pass maxSize to backend and let it know how much to compress instead of erroring out
+  const sizeLimit = maxSizeMB * (1024 * 1024);
+  if (file.size > sizeLimit) {
+    throw new Error(
+      `File size exceeded ${maxSizeMB} MB, Please compress and reupload.`
+    );
+  }
+
   return await uploadFileCommon(file, "image", false, filename);
 }
 


### PR DESCRIPTION
## Changes

- Remove the frontend compression with browser-image-resizer and move it to the backend with pillow instead. Never trust these npm packages they are mostly dogshit.
- Move the majority of filenaming to the backend too, currently a commit in `files` repo under static_files branch is handling it. https://github.com/Clubs-Council-IIITH/files/pull/7/commits/3a7f5cb9ff10908cb520906234c6a7848bf09365