### PR TITLE
profile: redirect 404 for empty profiles and disable clicking in MemberCard

### DIFF
--- a/src/app/profile/[id]/edit/page.jsx
+++ b/src/app/profile/[id]/edit/page.jsx
@@ -2,6 +2,7 @@ import { redirect, notFound } from "next/navigation";
 
 import { getClient } from "gql/client";
 import { GET_USER_PROFILE } from "gql/queries/users";
+import { GET_MEMBERSHIPS } from "gql/queries/clubs";
 
 import { Container } from "@mui/material";
 
@@ -26,7 +27,22 @@ export default async function EditProfile({ params }) {
     );
     const user = { ...userMeta, ...userProfile };
 
-    if (userProfile === null || userMeta === null) {
+
+    // get memberships if user is a person
+    let memberships = [];
+    const {
+      data: { memberRoles },
+    } = await getClient().query(GET_MEMBERSHIPS, {
+      uid: id,
+    });
+
+    // get list of memberRoles.roles along with member.cid
+    memberships = memberRoles.reduce(
+      (cv, m) => cv.concat(m.roles.map((r) => ({ ...r, cid: m.cid }))),
+      [],
+    );
+
+    if ((memberships?.length === 0 && currentUser?.uid !== user.uid) || userProfile === null || userMeta === null) {
       notFound();
     }
     // console.log(user);

--- a/src/app/profile/[id]/edit/page.jsx
+++ b/src/app/profile/[id]/edit/page.jsx
@@ -1,8 +1,9 @@
 import { redirect, notFound } from "next/navigation";
 
 import { getClient } from "gql/client";
-import { GET_USER_PROFILE } from "gql/queries/users";
+import { GET_USER } from "gql/queries/auth";
 import { GET_MEMBERSHIPS } from "gql/queries/clubs";
+import { GET_USER_PROFILE } from "gql/queries/users";
 
 import { Container } from "@mui/material";
 
@@ -15,49 +16,47 @@ export const metadata = {
 export default async function EditProfile({ params }) {
   const { id } = params;
 
-  try {
-    // get target user
-    const { data: { userProfile, userMeta } = {} } = await getClient().query(
-      GET_USER_PROFILE,
-      {
-        userInput: {
-          uid: id,
-        },
+  // get currently logged in user
+  const {
+    data: { userMeta: currentUserMeta, userProfile: currentUserProfile } = {},
+  } = await getClient().query(GET_USER, { userInput: null });
+  const currentUser = { ...currentUserMeta, ...currentUserProfile };
+
+  // get target user
+  const { data: { userProfile, userMeta } = {} } = await getClient().query(
+    GET_USER_PROFILE,
+    {
+      userInput: {
+        uid: id,
       },
-    );
-    const user = { ...userMeta, ...userProfile };
-
-
-    // get memberships if user is a person
-    let memberships = [];
-    const {
-      data: { memberRoles },
-    } = await getClient().query(GET_MEMBERSHIPS, {
-      uid: id,
-    });
-
-    // get list of memberRoles.roles along with member.cid
-    memberships = memberRoles.reduce(
-      (cv, m) => cv.concat(m.roles.map((r) => ({ ...r, cid: m.cid }))),
-      [],
-    );
-
-    if ((memberships?.length === 0 && currentUser?.uid !== user.uid) || userProfile === null || userMeta === null) {
-      notFound();
     }
-    // console.log(user);
+  );
+  const user = { ...userMeta, ...userProfile };
 
-    // if user is a club, redirect to club edit page
-    if (user.role === "club") {
-      redirect(`/manage/clubs/${user.uid}/edit`);
-    }
-
-    return (
-      <Container>
-        <UserForm defaultValues={user} action="save" />
-      </Container>
-    );
-  } catch (error) {
+  if (
+    userProfile === null ||
+    userMeta === null ||
+    (currentUser?.uid !== user?.uid && currentUser?.role !== "cc") ||
+    ["club", "cc"].includes(user?.role)
+  )
     redirect("/404");
+
+  // get memberships of the user
+  const {
+    data: { memberRoles },
+  } = await getClient().query(GET_MEMBERSHIPS, {
+    uid: id,
+  });
+  if (memberRoles?.length === 0) notFound();
+
+  // if user is a club, redirect to club edit page
+  if (user.role === "club") {
+    redirect(`/manage/clubs/${user.uid}/edit`);
   }
+
+  return (
+    <Container>
+      <UserForm defaultValues={user} action="save" />
+    </Container>
+  );
 }

--- a/src/app/profile/[id]/page.jsx
+++ b/src/app/profile/[id]/page.jsx
@@ -13,7 +13,7 @@ import UserDetails from "components/profile/UserDetails";
 import { EditUser } from "components/profile/UserActions";
 import UserMemberships from "components/profile/UserMemberships";
 
-export async function generateMetadata({ params }, parent) {
+export async function generateMetadata({ params }) {
   const { id } = params;
 
   try {
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }, parent) {
         userInput: {
           uid: id,
         },
-      },
+      }
     );
     const user = { ...userMeta, ...userProfile };
 
@@ -55,23 +55,23 @@ export default async function Profile({ params }) {
       userInput: {
         uid: id,
       },
-    },
+    }
   );
   const user = { ...userMeta, ...userProfile };
 
   // if user is a club, display the club's logo as profile picture
   let club = null;
-  if (user.role === "club") {
+  if (user?.role === "club") {
     const { data: { club: targetClub } = {} } = await getClient().query(
       GET_CLUB,
-      { clubInput: { cid: user.uid } },
+      { clubInput: { cid: user.uid } }
     );
     club = targetClub;
   }
 
   // get memberships if user is a person
   let memberships = [];
-  if (user.role === "public") {
+  if (user?.role === "public") {
     const {
       data: { memberRoles },
     } = await getClient().query(GET_MEMBERSHIPS, {
@@ -81,7 +81,7 @@ export default async function Profile({ params }) {
     // get list of memberRoles.roles along with member.cid
     memberships = memberRoles.reduce(
       (cv, m) => cv.concat(m.roles.map((r) => ({ ...r, cid: m.cid }))),
-      [],
+      []
     );
 
     if (memberships?.length === 0 && currentUser?.uid !== user.uid) {
@@ -96,10 +96,9 @@ export default async function Profile({ params }) {
         1. if current user is CC, or
         2. if current user is viewing their own profile and is not a club
       */}
-      {currentUser?.role === "cc" ||
-      (memberships?.length !== 0 &&
-        currentUser?.uid === user.uid &&
-        user.role !== "club") ? (
+      {user?.role !== "club" &&
+      (currentUser?.role === "cc" ||
+        (memberships?.length !== 0 && currentUser?.uid === user?.uid)) ? (
         <ActionPalette right={[EditUser]} />
       ) : null}
       <Grid container spacing={2} mt={4}>

--- a/src/app/profile/[id]/page.jsx
+++ b/src/app/profile/[id]/page.jsx
@@ -84,8 +84,7 @@ export default async function Profile({ params }) {
       [],
     );
 
-    console.log(memberships);
-    if (memberships?.length === 0) {
+    if (memberships?.length === 0 && currentUser?.uid !== user.uid) {
       notFound();
     }
   }
@@ -98,7 +97,9 @@ export default async function Profile({ params }) {
         2. if current user is viewing their own profile and is not a club
       */}
       {currentUser?.role === "cc" ||
-      (currentUser?.uid === user.uid && user.role !== "club") ? (
+      (memberships?.length !== 0 &&
+        currentUser?.uid === user.uid &&
+        user.role !== "club") ? (
         <ActionPalette right={[EditUser]} />
       ) : null}
       <Grid container spacing={2} mt={4}>
@@ -150,16 +151,23 @@ export default async function Profile({ params }) {
           </Stack>
         </Grid>
 
-        <Grid item xs={12} lg={9} mt={{ xs: 2, lg: 5 }}>
-          {user?.batch?.toLowerCase()?.includes("2k") ? ( // hacky way to exclude faculty and staff from rendering memberships
-            <Stack direction="column" spacing={2}>
-              <Typography variant="subtitle2" textTransform="uppercase">
-                Memberships
-              </Typography>
-              <UserMemberships rows={memberships} />
-            </Stack>
-          ) : null}
-        </Grid>
+        {/* Show user details only for students */}
+        {user?.batch?.toLowerCase()?.includes("2k") ? ( // hacky way to exclude faculty and staff
+          <>
+            <Grid item container xs spacing={2} mt={5}>
+              <UserDetails user={user} />
+            </Grid>
+
+            <Grid item xs={12} lg={9} mt={{ xs: 2, lg: 5 }}>
+              <Stack direction="column" spacing={2}>
+                <Typography variant="subtitle2" textTransform="uppercase">
+                  Memberships
+                </Typography>
+                <UserMemberships rows={memberships} />
+              </Stack>
+            </Grid>
+          </>
+        ) : null}
       </Grid>
     </Container>
   );

--- a/src/app/profile/[id]/page.jsx
+++ b/src/app/profile/[id]/page.jsx
@@ -96,7 +96,7 @@ export default async function Profile({ params }) {
         1. if current user is CC, or
         2. if current user is viewing their own profile and is not a club
       */}
-      {user?.role !== "club" &&
+      {!["club", "cc"].includes(user?.role) &&
       (currentUser?.role === "cc" ||
         (memberships?.length !== 0 && currentUser?.uid === user?.uid)) ? (
         <ActionPalette right={[EditUser]} />

--- a/src/app/profile/[id]/page.jsx
+++ b/src/app/profile/[id]/page.jsx
@@ -83,11 +83,16 @@ export default async function Profile({ params }) {
       (cv, m) => cv.concat(m.roles.map((r) => ({ ...r, cid: m.cid }))),
       [],
     );
+
+    console.log(memberships);
+    if (memberships?.length === 0) {
+      notFound();
+    }
   }
 
   return (
     <Container>
-      {/* 
+      {/*
         show action palette only
         1. if current user is CC, or
         2. if current user is viewing their own profile and is not a club
@@ -143,10 +148,6 @@ export default async function Profile({ params }) {
               </Typography>
             </Stack>
           </Stack>
-        </Grid>
-
-        <Grid item container xs spacing={2} mt={5}>
-          <UserDetails user={user} />
         </Grid>
 
         <Grid item xs={12} lg={9} mt={{ xs: 2, lg: 5 }}>

--- a/src/components/members/MemberCard.jsx
+++ b/src/components/members/MemberCard.jsx
@@ -35,6 +35,9 @@ export default async function MemberCard({ uid, poc, roles }) {
     user = { ...userMeta, ...userProfile1 };
   }
 
+  // Edge case for profile redirecting 404 for faculty in supervisory-bodies section
+  const clickable = user.role !== "public" || user.email.includes("student") || user.email.includes("research");
+
   return (
     <Card
       variant="outlined"
@@ -42,8 +45,7 @@ export default async function MemberCard({ uid, poc, roles }) {
       sx={{ backgroundColor: "inherit", border: "none", boxShadow: 0 }}
     >
       <CardActionArea
-        // TODO: Link to public user profile
-        component={Link}
+        component={clickable ? Link : "div"}
         href={`/profile/${uid}`}
         disabled={userProfile === null}
         sx={{

--- a/src/components/members/MemberCard.jsx
+++ b/src/components/members/MemberCard.jsx
@@ -35,8 +35,8 @@ export default async function MemberCard({ uid, poc, roles }) {
     user = { ...userMeta, ...userProfile1 };
   }
 
-  // Edge case for profile redirecting 404 for faculty in supervisory-bodies section
-  const clickable = user.role !== "public" || user.email.includes("student") || user.email.includes("research");
+  // Edge case for profile redirecting 404 for faculty/staff in supervisory-bodies section
+  const clickable = user?.role !== "public" || user?.email.includes("student") || user?.email.includes("research");
 
   return (
     <Card

--- a/src/components/profile/UserDetails.jsx
+++ b/src/components/profile/UserDetails.jsx
@@ -12,49 +12,51 @@ export default async function UserDetails({ user }) {
 
   return (
     <Stack direction="column" spacing={3} mx={2}>
-      <Box>
-        <Typography variant="subtitle2" textTransform="uppercase" gutterBottom>
-          User ID
-        </Typography>
-        <Typography fontWeight={400} fontFamily="monospace">
-          {user.uid}
-        </Typography>
-      </Box>
+      {currentUser?.uid ? (
+        <Box>
+          <Typography
+            variant="subtitle2"
+            textTransform="uppercase"
+            gutterBottom
+          >
+            User ID
+          </Typography>
+          <Typography fontWeight={400} fontFamily="monospace">
+            {user.uid}
+          </Typography>
+        </Box>
+      ) : null}
 
       {user?.role !== "club" ? (
         <>
-          {user?.batch?.toLowerCase()?.includes("2k") ? ( // hacky way to exclude faculty and staff from rendering batch and stream
-            <Box>
-              <Typography
-                variant="subtitle2"
-                textTransform="uppercase"
-                gutterBottom
-              >
-                Batch
-              </Typography>
-              <Typography fontWeight={400} textTransform="uppercase">
-                {user.batch} · {user.stream}
-              </Typography>
-            </Box>
-          ) : null}
+          <Box>
+            <Typography
+              variant="subtitle2"
+              textTransform="uppercase"
+              gutterBottom
+            >
+              Batch
+            </Typography>
+            <Typography fontWeight={400} textTransform="uppercase">
+              {user.batch} · {user.stream}
+            </Typography>
+          </Box>
 
           {["cc", "slo", "slc"].includes(currentUser?.role) ||
           (currentUser?.uid === user?.uid && user?.role !== "club") ? (
             <>
-              {user?.batch?.toLowerCase()?.includes("2k") ? (
-                <Box>
-                  <Typography
-                    variant="subtitle2"
-                    textTransform="uppercase"
-                    gutterBottom
-                  >
-                    Roll Number
-                  </Typography>
-                  <Typography fontWeight={400}>
-                    {user.rollno || "Unknown"}
-                  </Typography>
-                </Box>
-              ) : null}
+              <Box>
+                <Typography
+                  variant="subtitle2"
+                  textTransform="uppercase"
+                  gutterBottom
+                >
+                  Roll Number
+                </Typography>
+                <Typography fontWeight={400}>
+                  {user.rollno || "Unknown"}
+                </Typography>
+              </Box>
               <Box>
                 <Typography
                   variant="subtitle2"


### PR DESCRIPTION
## Changes

- After talks with SLO and IT-Head, we should really disable random LDAP searches happening and userProfiles getting rendred for random people, since it can reveal info like email and full name, just from the uid.
- Also any random person can login and set a profile picture, which is a waste of storage.
- Now all the member cards should ideally redirect to a valid url (because the page belonging to the membercard itself will the membership entry). But in one case (SAC members), there is no membership entry for them, so the roles table is empty. So temporary fix is to check if they are faculty and disable hrefs. A more permanent fix will add an entry in the memberships table for these SAC members