### PR TITLE
Imageupload: fix damage done by force-push in imageupload

### DIFF
--- a/src/utils/files.jsx
+++ b/src/utils/files.jsx
@@ -49,15 +49,18 @@ export async function uploadImageFile(file, filename = null, maxSizeMB = 0.3) {
   // construct filename
   const ext = file.name.split(".").pop();
   filename = filename ? `${filename}.${ext}` : file.name;
+  let underlimit = true;
 
-  const finalFilename = await uploadFileCommon(
-    file,
-    "image",
-    false,
-    filename,
-    maxSizeMB,
-  );
-  return finalFilename;
+  // check file size limits
+  const sizeLimit = maxSizeMB * (1024 * 1024);
+  if (file.size > sizeLimit) {
+    underlimit = false;
+  }
+
+  return await {
+    underlimit: underlimit,
+    filename: await uploadFileCommon(file, "image", false, filename, maxSizeMB),
+  }
 }
 
 export async function uploadPDFFile(


### PR DESCRIPTION
# Changesss

Adds back  the proper return value, that was deleted in this commit. https://github.com/Clubs-Council-IIITH/web/compare/333ce9ebabd38f53dc08bd57bc85db6f4f1d26ba..d9da6a0984fca6654a3daf8fb59e5afc13e2dfef