### PR TITLE
logging: add timestamp prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules
 node_modules/
 .next/

--- a/next.config.js
+++ b/next.config.js
@@ -2,10 +2,19 @@
   const original = console[method];
   console[method] = (...args) => {
     const now = new Date();
-    const formattedDate = 
-      `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')} ` +
-      `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
-    original(`[${formattedDate}]`, ...args);
+    
+    const formattedDate = now.toLocaleString('en-US', {
+      timeZone: 'Asia/Kolkata',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false
+    }).replace(/(\d+)\/(\d+)\/(\d+),\s(\d+):(\d+):(\d+)/, '[$3/$1/$2 $4:$5:$6]');
+    
+    original(`${formattedDate} - `, ...args);
   };
 });
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,14 @@
+['log', 'warn', 'error', 'info', 'debug'].forEach((method) => {
+  const original = console[method];
+  console[method] = (...args) => {
+    const now = new Date();
+    const formattedDate = 
+      `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')} ` +
+      `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
+    original(`[${formattedDate}]`, ...args);
+  };
+});
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,


### PR DESCRIPTION
## Reason

- The logs messages from docker are hard to read and sometimes confusing because they mixup in chronological order. 

## Changes

- Add custom method implementation for all logging methods like log, warn,error, info, debug.

## Related PRs

- https://github.com/Clubs-Council-IIITH/services/pull/65
- https://github.com/Clubs-Council-IIITH/users/pull/24
- https://github.com/Clubs-Council-IIITH/members/pull/18
- https://github.com/Clubs-Council-IIITH/events/pull/63
- https://github.com/Clubs-Council-IIITH/interfaces/pull/24
- https://github.com/Clubs-Council-IIITH/files/pull/15
- https://github.com/Clubs-Council-IIITH/clubs/pull/25
- https://github.com/Clubs-Council-IIITH/auth/pull/11
- https://github.com/Clubs-Council-IIITH/auth-dev/pull/10
- https://github.com/Clubs-Council-IIITH/gateway/pull/7