### PR TITLE
add form entry for external participants and display it in manage/events

### DIFF
--- a/src/app/manage/events/[id]/page.jsx
+++ b/src/app/manage/events/[id]/page.jsx
@@ -199,29 +199,7 @@ export default async function ManageEventID({ params }) {
                   </Box>
                 ) : null}
 
-
-                <Grid container spacing={2} mt={0.1}>
-                  <Grid item xs={4}>
-                    <Box>
-                      <Typography variant="overline">Population</Typography>
-                      <Typography variant="body2">
-                        {event?.population || 0}
-                      </Typography>
-                    </Box>
-                  </Grid>
-                  {event?.externalPopulation && event.externalPopulation > 0 ? (
-                    <Grid item xs={4}>
-                      <Box>
-                        <Typography variant="overline">External Population</Typography>
-                        <Typography variant="body2">
-                          {event?.externalPopulation || 0}
-                        </Typography>
-                      </Box>
-                    </Grid>
-                  ) : null}
-                </Grid>
-
-                <Box mt={2}>
+               <Box mt={2}>
                   <Typography variant="overline">Equipment</Typography>
                   <Typography variant="body2">
                     {event?.equipment || "None"}
@@ -240,6 +218,27 @@ export default async function ManageEventID({ params }) {
             ) : (
               <Box mt={2}>None requested</Box>
             )}
+
+            <Grid container spacing={2} mt={0.1}>
+              <Grid item xs={4}>
+                <Box>
+                  <Typography variant="overline">Population</Typography>
+                  <Typography variant="body2">
+                    {event?.population || 0}
+                  </Typography>
+                </Box>
+              </Grid>
+              {event?.externalPopulation && event.externalPopulation > 0 ? (
+                <Grid item xs={4}>
+                  <Box>
+                    <Typography variant="overline">External Population</Typography>
+                    <Typography variant="body2">
+                      {event?.externalPopulation || 0}
+                    </Typography>
+                  </Box>
+                </Grid>
+              ) : null}
+            </Grid>
           </Grid>
         </Grid>
 

--- a/src/app/manage/events/[id]/page.jsx
+++ b/src/app/manage/events/[id]/page.jsx
@@ -199,12 +199,27 @@ export default async function ManageEventID({ params }) {
                   </Box>
                 ) : null}
 
-                <Box mt={2}>
-                  <Typography variant="overline">Population</Typography>
-                  <Typography variant="body2">
-                    {event?.population || 0}
-                  </Typography>
-                </Box>
+
+                <Grid container spacing={2} mt={0.1}>
+                  <Grid item xs={4}>
+                    <Box>
+                      <Typography variant="overline">Population</Typography>
+                      <Typography variant="body2">
+                        {event?.population || 0}
+                      </Typography>
+                    </Box>
+                  </Grid>
+                  {event?.externalPopulation && event.externalPopulation > 0 ? (
+                    <Grid item xs={4}>
+                      <Box>
+                        <Typography variant="overline">External Population</Typography>
+                        <Typography variant="body2">
+                          {event?.externalPopulation || 0}
+                        </Typography>
+                      </Box>
+                    </Grid>
+                  ) : null}
+                </Grid>
 
                 <Box mt={2}>
                   <Typography variant="overline">Equipment</Typography>

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -100,6 +100,7 @@ export default function EventForm({
   }, []);
 
   const { control, handleSubmit, watch, resetField, setValue } = useForm({
+    mode: 'onChange',
     defaultValues,
   });
   const collabEvent = watch("collabEvent");
@@ -235,6 +236,7 @@ export default function EventForm({
       locationAlternate:
         formData.mode === "online" ? null : formData.locationAlternate,
       population: parseInt(formData.population),
+      externalPopulation: parseInt(formData.externalPopulation),
       additional: formData.additional,
       equipment: formData.equipment,
       poc: formData.poc,
@@ -1092,6 +1094,7 @@ function EventVenueInput({
   const locationInput = watch("location");
   const startDateInput = watch("datetimeperiod.0");
   const endDateInput = watch("datetimeperiod.1");
+  const externalAllowed = watch("externalAllowed");
 
   // reset location if datetime changes
   useEffect(() => resetField("location"), [startDateInput, endDateInput]);
@@ -1156,6 +1159,7 @@ function EventVenueInput({
           name="population"
           control={control}
           rules={{
+            required: "Participation count is required.",
             min: {
               value: 1,
               message: "Expected participation count must be at least 1.",
@@ -1179,6 +1183,67 @@ function EventVenueInput({
           )}
         />
       </Grid>
+
+      <FormControlLabel
+        control={
+          <Controller
+            name="externalAllowed"
+            control={control}
+            render={({ field }) => (
+              <Switch
+                checked={field.value}
+                onChange={(e) => field.onChange(e.target.checked)}
+                inputProps={{ "aria-label": "controlled" }}
+                sx={{ m: 2 }}
+              />
+            )}
+          />
+        }
+        label="External Particpants"
+      />
+
+      {externalAllowed ? (
+        <Grid item xs={12}>
+          <Controller
+            name="externalPopulation"
+            control={control}
+            rules={{
+              required: "External participation count is required if enabled.",
+              min: {
+                value: 1,
+                message: "External participation count must be at least 1 if enabled.",
+              },
+              validate: (value, formValues) => {
+                const population = formValues.population;
+                const externalPopulationValue = Number(value);
+                const populationValue = Number(population);
+
+                if (externalPopulationValue > populationValue) {
+                  return "External participation count must be less than total participants.";
+                }
+                return true;
+              },
+            }}
+            defaultValue={0}
+            render={({ field, fieldState: { error, invalid } }) => (
+              <TextField
+                type="number"
+                label="Expected External Participation*"
+                error={invalid}
+                helperText={error?.message}
+                autoComplete="off"
+                variant="outlined"
+                fullWidth
+                InputProps={{
+                  inputProps: { min: 1 },
+                }}
+                disabled={false}
+                {...field}
+              />
+            )}
+          />
+        </Grid>
+      ): null}
 
       {/* show location details input if venue is requested */}
       {locationInput?.length ? (

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -509,6 +509,7 @@ export default function EventForm({
                   control={control}
                   watch={watch}
                   resetField={resetField}
+                  defaultValues={defaultValues}
                   disabled={
                     !admin_roles.includes(user?.role) &&
                     defaultValues?.status?.state != undefined &&
@@ -1086,6 +1087,7 @@ function EventDescriptionInput({ control }) {
 function EventVenueInput({
   control,
   watch,
+  defaultValues,
   resetField,
   disabled = true,
   eventid = null,
@@ -1189,6 +1191,10 @@ function EventVenueInput({
           <Controller
             name="externalAllowed"
             control={control}
+            defaultValue={
+              defaultValues.externalPopulation &&
+              defaultValues.externalPopulation > 0
+            }
             render={({ field }) => (
               <Switch
                 checked={field.value}

--- a/src/components/events/report/EventDocxDownloads.jsx
+++ b/src/components/events/report/EventDocxDownloads.jsx
@@ -429,7 +429,28 @@ export function DownloadEventReportDocx({
                 }),
               ],
             }),
-
+            new Paragraph({
+              children: [
+                new TextRun({
+                  text: "Estimated External Participation: ",
+                  bold: true,
+                }),
+                new TextRun({
+                  text: `${event?.externalPopulation || "N/A"}`,
+                }),
+              ],
+            }),
+            new Paragraph({
+              children: [
+                new TextRun({
+                  text: "Actual external Attendance: ",
+                  bold: true,
+                }),
+                new TextRun({
+                  text: `${eventReport?.externalAttendance || "N/A"}`,
+                }),
+              ],
+            }),
             new Paragraph({
               text: "Venue Information",
               heading: "Heading2",

--- a/src/components/events/report/EventReportDetails.jsx
+++ b/src/components/events/report/EventReportDetails.jsx
@@ -152,16 +152,49 @@ export function EventReportDetails({
             <Typography variant="overline">Mode</Typography>
             <Typography variant="body2">{event?.mode || "None"}</Typography>
           </Box>
-          <Box mt={2}>
-            <Typography variant="overline">Estimated Population</Typography>
-            <Typography variant="body2">{event?.population || 0}</Typography>
-          </Box>
-          <Box mt={2}>
-            <Typography variant="overline">Attended Population</Typography>
-            <Typography variant="body2">
-              {eventReport?.attendance || "None"}
-            </Typography>
-          </Box>
+          <Grid container spacing={2} mt={0.1} mb={4}>
+            <Grid item xs={4}>
+              <Box>
+                <Typography variant="overline">Estimated</Typography>
+                <Typography variant="body2">{event?.population || 0}</Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={4}>
+              <Box>
+                <Typography variant="overline">Attended</Typography>
+                <Typography variant="body2">
+                  {eventReport?.attendance || "None"}
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+          { event?.externalPopulation ? (
+            <>
+              <Typography
+                variant="subtitle2"
+                textTransform="uppercase"
+                gutterBottom
+              >
+                EXTERNAL ATTENDANCE
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={4}>
+                  <Box>
+                    <Typography variant="overline">Estimated</Typography>
+                    <Typography variant="body2">{event?.externalPopulation || 0}</Typography>
+                  </Box>
+                </Grid>
+                <Grid item xs={4}>
+                  <Box>
+                    <Typography variant="overline">Attended</Typography>
+                    <Typography variant="body2">
+                      {eventReport?.externalAttendance || "None"}
+                    </Typography>
+                  </Box>
+                </Grid>
+              </Grid>
+            </>
+          ): null}
         </Grid>
 
         <Grid item xs={12} md={4} sm={6}>

--- a/src/components/events/report/EventReportForm.jsx
+++ b/src/components/events/report/EventReportForm.jsx
@@ -159,7 +159,8 @@ export default function EventReportForm({
       const reportData = {
         eventid: id,
         summary: formData.eventSummary,
-        attendance: parseInt(formData.actualAttendance, 10),
+        attendance: parseInt(formData.actualAttendance, 0),
+        externalAttendance: parseInt(formData.actualExternalAttendance, null),
         prizes: formData.prizes || [],
         prizesBreakdown: formData.prizesBreakdown || "N/A",
         winners: formData.winnersDetails || "N/A",
@@ -385,7 +386,7 @@ export default function EventReportForm({
                 fullWidth
               />
             </Grid>
-            <Grid item xs={12} mt={2}>
+            <Grid item xs={12} mt={2} mb={3}>
               <Controller
                 name="actualAttendance"
                 control={control}
@@ -404,6 +405,38 @@ export default function EventReportForm({
                 )}
               />
             </Grid>
+            { defaultValues?.externalPopulation ? (
+              <>
+                <Grid item xs={12}>
+                  <TextField
+                    label="Expected External Participation"
+                    value={defaultValues?.population}
+                    disabled
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} mt={2}>
+                  <Controller
+                    name="actualExternalAttendance"
+                    control={control}
+                    rules={{ required: "Actual External Attendance is required!" }}
+                    defaultValue={defaultReportValues?.externalAttendance}
+                    render={({ field, fieldState: { error, invalid } }) => (
+                      <TextField
+                        {...field}
+                        label="Actual External Attendance*"
+                        type="number"
+                        fullWidth
+                        error={invalid}
+                        helperText={error?.message}
+                        autoComplete="off"
+                      />
+                    )}
+                  />
+                </Grid>
+              </>
+            ): null }
+
             <Grid item xs={12} mt={2}>
               <Controller
                 name="prizes"

--- a/src/components/events/report/EventpdfDownloads.jsx
+++ b/src/components/events/report/EventpdfDownloads.jsx
@@ -213,7 +213,7 @@ export function DownloadEventReport({
                 : `<p class="no-data">No budget details available.</p>`
             }
         </div>
-        
+
         <div class="section">
             <h2>Participation Overview</h2>
             <p><strong>Audience:</strong> ${
@@ -229,6 +229,13 @@ export function DownloadEventReport({
             <p><strong>Actual Attendance:</strong> ${
               eventReport?.attendance || "N/A"
             }</p>
+            <p><strong>Estimated External Participation:</strong> ${
+              event?.externalPopulation || "N/A"
+            }</p>
+            <p><strong>Actual External Attendance:</strong> ${
+              eventReport?.externalAttendance || "N/A"
+            }</p>
+
         </div>
         <div class="section">
             <h2>Venue Information</h2>
@@ -705,7 +712,7 @@ export function DownloadEvent({ event, clubs, pocProfile, eventBills }) {
         <p><strong>Clubs Council Approved By:</strong> ${
           event?.status?.ccApprover || "Information not available"
         }</p>
-        
+
         <p><strong>Students Life Council Approval:</strong> ${
           event?.status?.slcApproverTime || "Information not available"
         }</p>
@@ -716,7 +723,7 @@ export function DownloadEvent({ event, clubs, pocProfile, eventBills }) {
             : ""
         }
         </div>
-            
+
         ${
           event?.budget?.length
             ? `

--- a/src/gql/queries/events.jsx
+++ b/src/gql/queries/events.jsx
@@ -238,6 +238,7 @@ export const GET_EVENT_REPORT = gql`
       eventid
       summary
       attendance
+      externalAttendance
       prizes
       prizesBreakdown
       winners

--- a/src/gql/queries/events.jsx
+++ b/src/gql/queries/events.jsx
@@ -172,6 +172,7 @@ export const GET_FULL_EVENT = gql`
       mode
       name
       population
+      externalPopulation
       poster
       status {
         state


### PR DESCRIPTION
## Changes
- Add a new form entry to record the external participants, only when the slider allowing external participants is enabled.
- Add a new column in the manage/events page to show the external partipants count
- Add  conditions for external participants to be lower than total

## Linked PRs
- https://github.com/Clubs-Council-IIITH/events/pull/66