### PR TITLE
EventForm: Handle location clash while approving events

### DIFF
--- a/src/app/manage/events/[id]/approve_cc/page.jsx
+++ b/src/app/manage/events/[id]/approve_cc/page.jsx
@@ -8,6 +8,7 @@ import { Container, Typography } from "@mui/material";
 
 import { techTeamWords } from "constants/ccMembersFilterWords";
 import { extractFirstYear } from "components/members/MembersGrid";
+import { GET_ALL_EVENTS } from "gql/queries/events";
 import EventActionTabs from "components/events/EventActionTabs";
 
 export const metadata = {
@@ -31,6 +32,10 @@ export default async function ApproveEventCC({ params }) {
     },
   });
 
+  const { data: { events } = {} } = await getClient().query(GET_ALL_EVENTS, {
+    clubid: null,
+    public: false,
+  });
   const ccMembers = members
     ?.map((member) => {
       const { roles } = member;
@@ -52,7 +57,8 @@ export default async function ApproveEventCC({ params }) {
         return false;
       })
     : [];
-
+  
+  const curr_event = events.find(temp=>temp._id === event._id)
   return (
     user?.role !== "cc" && redirect("/404"),
     event?.status?.state !== "pending_cc" && redirect("/404"),
@@ -64,7 +70,7 @@ export default async function ApproveEventCC({ params }) {
           </Typography>
         </center>
 
-        <EventActionTabs eventid={event._id} members={currentccMembers} />
+        <EventActionTabs eventid={event._id} eventLocation={curr_event.location} eventStart={curr_event.datetimeperiod[0]} eventEnd={curr_event.datetimeperiod[1]} members={currentccMembers} existingEvents={events} />
       </Container>
     )
   );

--- a/src/app/manage/events/[id]/page.jsx
+++ b/src/app/manage/events/[id]/page.jsx
@@ -2,6 +2,7 @@ import { getClient } from "gql/client";
 import { GET_FULL_EVENT, GET_EVENT_BILLS_STATUS } from "gql/queries/events";
 import { GET_ACTIVE_CLUBS } from "gql/queries/clubs";
 import { GET_USER } from "gql/queries/auth";
+import { GET_ALL_EVENTS } from "gql/queries/events";
 import { getFullUser } from "actions/users/get/full/server_action";
 
 import {
@@ -26,6 +27,7 @@ import {
   EditEvent,
   CopyEvent,
   ApproveEvent,
+  LocationClashApproval,
   ProgressEvent,
   DeleteEvent,
   SubmitEvent,
@@ -40,6 +42,34 @@ import {
 
 import { locationLabel } from "utils/formatEvent";
 import MemberListItem from "components/members/MemberListItem";
+
+function filterClashingEvents(events, startTime, endTime, inputLocations) {
+  const inputLocs = Array.isArray(inputLocations)
+    ? inputLocations.map((loc) => loc.toLowerCase().trim())
+    : [inputLocations.toLowerCase().trim()];
+
+  const clashingEvents = events.filter((event) => {
+
+    if (!event.status || event.status.state !== "approved") return false;
+    const eventStart = new Date(event.datetimeperiod[0]);
+    const eventEnd = new Date(event.datetimeperiod[1]);
+
+    const isTimeClashing =
+      (startTime >= eventStart && startTime < eventEnd) ||
+      (endTime > eventStart && endTime <= eventEnd) ||
+      (startTime <= eventStart && endTime >= eventEnd);
+
+    const eventLocs = Array.isArray(event.location)
+      ? event.location.map((loc) => loc.toLowerCase().trim())
+      : [event.location.toLowerCase().trim()];
+
+    const isLocationClashing = eventLocs.some((loc) => inputLocs.includes(loc));
+
+    return isTimeClashing && isLocationClashing;
+  });
+
+  return clashingEvents.length ? clashingEvents : null;
+}
 
 export async function generateMetadata({ params }) {
   const { id } = params;
@@ -87,6 +117,11 @@ export default async function ManageEventID({ params }) {
     data: { activeClubs },
   } = await getClient().query(GET_ACTIVE_CLUBS);
 
+  const { data: { events } = {} } = await getClient().query(GET_ALL_EVENTS, {
+    clubid: null,
+    public: false,
+  });
+
   const { data: { userMeta, userProfile } = {} } = await getClient().query(
     GET_USER,
     { userInput: null },
@@ -100,6 +135,11 @@ export default async function ManageEventID({ params }) {
   if (!pocProfile) {
     return redirect("/404");
   }
+  const eventStart = new Date(event.datetimeperiod[0]);
+  const eventEnd = new Date(event.datetimeperiod[1]);
+  const clashing_events = filterClashingEvents(events, eventStart, eventEnd, event.location);
+  
+  const clashFlag = clashing_events != null && clashing_events.length > 0 ? true : false;
 
   return (
     user?.role === "club" &&
@@ -115,7 +155,7 @@ export default async function ManageEventID({ params }) {
             { status: event?.status, budget: event?.budget },
             { status: event?.status, location: event?.location },
           ]}
-          right={getActions(event, { ...userMeta, ...userProfile })}
+          right={getActions(event, clashFlag, { ...userMeta, ...userProfile })}
           downloadbtn={
             <DownloadEvent
               event={event}
@@ -242,7 +282,7 @@ export default async function ManageEventID({ params }) {
 }
 
 // set conditional actions based on event datetime, current status and user role
-function getActions(event, user) {
+function getActions(event, clashFlag, user) {
   const upcoming = new Date(event?.datetimeperiod[0]) >= new Date();
   /*
    * Deleted Event
@@ -290,8 +330,11 @@ function getActions(event, user) {
       // upcoming &&
       event?.status?.state === "pending_budget" &&
       !event?.status?.budget
-    )
+    ){
+      if(clashFlag)
+        return [LocationClashApproval];
       return [ApproveEvent];
+    }
     else return [];
   }
 
@@ -305,8 +348,11 @@ function getActions(event, user) {
       event?.status?.state === "pending_room" &&
       (event?.status?.budget || event?.clubCategory == "body") &&
       !event?.status?.room
-    )
+    ){
+      if(clashFlag)
+        return [LocationClashApproval, EditEvent, DeleteEvent]
       return [ApproveEvent, EditEvent, DeleteEvent];
+    }
     else if (
       event?.status?.state === "approved" &&
       !upcoming &&

--- a/src/app/manage/events/[id]/page.jsx
+++ b/src/app/manage/events/[id]/page.jsx
@@ -331,8 +331,6 @@ function getActions(event, clashFlag, user) {
       event?.status?.state === "pending_budget" &&
       !event?.status?.budget
     ){
-      if(clashFlag)
-        return [LocationClashApproval];
       return [ApproveEvent];
     }
     else return [];

--- a/src/components/events/EventActionTabs.jsx
+++ b/src/components/events/EventActionTabs.jsx
@@ -37,8 +37,6 @@ function filterClashingEvents(events, startTime, endTime, inputLocations) {
     ? inputLocations.map((loc) => loc.toLowerCase().trim())
     : [inputLocations.toLowerCase().trim()];
 
-  console.log("inputLocations:", inputLocations);
-  console.log("inputLocs:", inputLocs);
 
   const clashingEvents = events.filter((event) => {
 

--- a/src/components/events/EventActions.jsx
+++ b/src/components/events/EventActions.jsx
@@ -210,7 +210,33 @@ export function ApproveEvent({ sx }) {
     </>
   );
 }
+export function LocationClashApproval({sx}) {
+  const [dialog, setDialog] = useState(false);
+  return (
+    <>
+      <Button
+        variant="contained"
+        color="warning"
+        startIcon={<Icon variant="done" />}
+        onClick={() => setDialog(true)}
+        sx={sx}
+      >
+        Approve
+      </Button>
 
+      <ConfirmDialog
+        open={dialog}
+        title= "Location Clash Detected"
+        description="The location selected for this event is clashing with another booking. Please change the location before approval."
+        onConfirm={() => setDialog(false)}
+        onClose={() => setDialog(false)}
+        confirmProps={{ color:  "warning"}}
+        confirmText="Close"
+
+      />
+    </>
+  );
+}
 export function ProgressEvent({ sx }) {
   const { id } = useParams();
   return (


### PR DESCRIPTION
It was discussed in PR #145 ( It handles the second point which i mentioned while reviewing the PR ).

Before if two events demanded the same location then both could have been approved, despite being an overlap.

This PR checks for an overlap on time period and location between the being approved event and all approved events, and doesn't allow to approve if the location has already been assigned.

This works on both CC & SLO side approvals.