### PR TITLE
replace sponsor website with comment

### DIFF
--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -336,7 +336,7 @@ export default function EventForm({
       .filter((i) => i?.name)
       .map((i) => ({
         name: i.name,
-        website: i.website,
+        comment: i.comment,
         amount: i.amount,
         previouslySponsored: i.previouslySponsored,
       }));

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -334,6 +334,7 @@ export default function EventForm({
 
     data.sponsor = formData.sponsor
       .filter((i) => i?.name)
+      .filter((i) => i?.amount >= 0)
       .map((i) => ({
         name: i.name,
         comment: i.comment,

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -343,10 +343,10 @@ export default function EventForm({
       }));
 
     // Check if description increases the character limit
-    if (data.sponsor.some((i) => i.comment?.length > 100)) {
+    if (data.sponsor.some((i) => i.comment?.length > 200)) {
       triggerToast({
         title: "Character Limit Exceeded!",
-        messages: ["Please keep sponsor comment below 100 characters"],
+        messages: ["Please keep sponsor comment below 200 characters"],
         severity: "error",
       });
       setLoading(false);

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -342,6 +342,17 @@ export default function EventForm({
         previouslySponsored: i.previouslySponsored,
       }));
 
+    // Check if description increases the character limit
+    if (data.sponsor.some((i) => i.comment?.length > 100)) {
+      triggerToast({
+        title: "Character Limit Exceeded!",
+        messages: ["Please keep sponsor comment below 100 characters"],
+        severity: "error",
+      });
+      setLoading(false);
+      return;
+    }
+
     // TODO: fix event link field
     data.link = null;
 

--- a/src/components/events/EventSponsor.jsx
+++ b/src/components/events/EventSponsor.jsx
@@ -23,7 +23,7 @@ export default function EventSponsor({
   // budget item template
   const emptySponsorItem = {
     name: null,
-    website: null,
+    comment: null,
     amount: 0,
     previouslySponsored: false,
   };
@@ -87,8 +87,8 @@ export default function EventSponsor({
       display: "flex",
     },
     {
-      field: "website",
-      headerName: "Official Website",
+      field: "comment",
+      headerName: "Comments",
       width: 200,
       flex: isMobile ? null : 1.75,
       editable: editable,

--- a/src/components/events/report/EventDocxDownloads.jsx
+++ b/src/components/events/report/EventDocxDownloads.jsx
@@ -452,7 +452,7 @@ export function DownloadEventReportDocx({
                             new Paragraph({
                               children: [
                                 new TextRun({
-                                  text: "Official Website",
+                                  text: "Comment",
                                   bold: true,
                                 }),
                               ],
@@ -502,7 +502,7 @@ export function DownloadEventReportDocx({
                             }),
                             new TableCell({
                               children: [
-                                new Paragraph(item?.website || "Unknown"),
+                                new Paragraph(item?.comment || "Unknown"),
                               ],
                               width: {
                                 size: 50,

--- a/src/components/events/report/EventpdfDownloads.jsx
+++ b/src/components/events/report/EventpdfDownloads.jsx
@@ -139,7 +139,7 @@ export function DownloadEventReport({
             white-space: normal;
         }
 
-        .website {
+        .comment {
             word-break: break-all;
             overflow-wrap: anywhere;
         }
@@ -231,7 +231,7 @@ export function DownloadEventReport({
                         <th>Sponsor Name</th>
                         <th class="adv">Amount</th>
                         <th class="adv">Previously Sponsored?</th>
-                        <th class="adv">Official Website</th>
+                        <th class="adv">Comments</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -246,7 +246,7 @@ export function DownloadEventReport({
                         <td class="adv">${
                           item?.previously_sponsored == true ? "Yes" : "No"
                         }</td>
-                        <td class="website adv">${item?.website || "Unknown"}</td>
+                        <td class="comment adv">${item?.comment || "Unknown"}</td>
                     </tr>
                     `,
                       )

--- a/src/gql/queries/events.jsx
+++ b/src/gql/queries/events.jsx
@@ -178,9 +178,9 @@ export const GET_FULL_EVENT = gql`
       }
       sponsor {
         name
-        website
         amount
         previouslySponsored
+        comment
       }
       clubid
       collabclubs


### PR DESCRIPTION
## Changes

- Change EventForm and EventSponsor to have comment instead of websites
- Change queries accordingly
- Change EventReport stuff from website to comment
- Add back amount positive checking when submitting, removed in https://github.com/Clubs-Council-IIITH/web/commit/231c402f19638c143f24dc8ae23c0c1aba77b3a1#r165857143


## Related PRs

https://github.com/Clubs-Council-IIITH/events/pull/78